### PR TITLE
Indentation inconsistency

### DIFF
--- a/wrapper/symbols/crypto_generichash_init.json
+++ b/wrapper/symbols/crypto_generichash_init.json
@@ -20,5 +20,5 @@
 	],
 	"target": "libsodium._crypto_generichash_init(state_address, key_address, key_length, hash_length) | 0",
 	"expect": "=== 0",
-    "return": "state_address"
+	"return": "state_address"
 }

--- a/wrapper/symbols/crypto_onetimeauth_final.json
+++ b/wrapper/symbols/crypto_onetimeauth_final.json
@@ -17,5 +17,5 @@
 	],
 	"target": "libsodium._crypto_onetimeauth_final(state_address, hash_address) | 0",
 	"expect": "=== 0",
-    "return": "(libsodium._free(state_address), _format_output(hash, outputFormat))"
+	"return": "(libsodium._free(state_address), _format_output(hash, outputFormat))"
 }

--- a/wrapper/symbols/crypto_onetimeauth_init.json
+++ b/wrapper/symbols/crypto_onetimeauth_init.json
@@ -16,5 +16,5 @@
 	],
 	"target": "libsodium._crypto_onetimeauth_init(state_address, key_address) | 0",
 	"expect": "=== 0",
-    "return": "state_address"
+	"return": "state_address"
 }


### PR DESCRIPTION
Just noticed that the onetimeauth files I added in #25 had a tab/space indentation inconsistency copied from the equivalent generichash files; fixed both that and the original generichash mistake that I'd copied from.