### PR TITLE
Added missing requirement to compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ need to be installed on your system:
 * libtool
 * make
 * zopfli (`npm install -g node-zopfli`)
+* uglifyjs (`npm install -g uglifyjs`)
 
 Running `make` will clone libsodium, build it, test it, build the
 wrapper, and create the modules and minified distribution files.


### PR DESCRIPTION
When compiling the libsodium.js, uglifyjs is required. Just added this requirement to README.