### PR TITLE
Fix dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ need to be installed on your system:
 * libtool
 * make
 * zopfli (`npm install -g node-zopfli`)
-* uglifyjs (`npm install -g uglifyjs`)
+* uglifyjs (`npm install -g uglify-js`)
 
 Running `make` will clone libsodium, build it, test it, build the
 wrapper, and create the modules and minified distribution files.


### PR DESCRIPTION
The README currently instructs one to download the incorrect npm package for [Uglify](https://github.com/mishoo/UglifyJS2). The correct package name is **uglify-js**. The package currently listed does not appear to be legitimate and could be potentially malicious.