### PR TITLE
README: update links to point to new locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,17 +79,17 @@ console.log(sodium.to_hex(sodium.crypto_generichash(64, 'test')));
 * [`crypto_aead`](https://download.libsodium.org/doc/secret-key_cryptography/aead.html) (ChaCha20-Poly1305)
 * [`crypto_auth`](https://download.libsodium.org/doc/secret-key_cryptography/secret-key_authentication.html) (HMAC-SHA-512-256)
 * [`crypto_box`](https://doc.libsodium.org/public-key_cryptography/authenticated_encryption.html)
-* [`crypto_box_seal`](https://doc.libsodium.org/public-key_cryptography/sealed_boxes.html)
-* [`crypto_generichash`](https://doc.libsodium.org/hashing/generic_hashing.html) (Blake2b)
-* [`crypto_hash`](https://doc.libsodium.org/advanced/sha-2_hash_function.html) (SHA-512-256)
-* [`crypto_onetimeauth`](https://doc.libsodium.org/advanced/poly1305.html) (Poly1305)
-* [`crypto_pwhash`](https://download.libsodium.org/doc/password_hashing/index.html) (Argon2)
-* [`crypto_scalarmult`](https://doc.libsodium.org/advanced/scalar_multiplication.html) (Curve25519)
-* [`crypto_secretbox`](https://doc.libsodium.org/secret-key_cryptography/authenticated_encryption.html)
-* [`crypto_shorthash`](https://doc.libsodium.org/hashing/short-input_hashing.html) (SipHash)
-* [`crypto_sign`](https://doc.libsodium.org/public-key_cryptography/public-key_signatures.html) (Ed25519)
-* [Ed25519->Curve25519 conversion](https://doc.libsodium.org/advanced/ed25519-curve25519.html)
-* [`randombytes`](https://doc.libsodium.org/generating_random_data/README.html)
+* [`crypto_box_seal`](https://download.libsodium.org/libsodium/content/public-key_cryptography/sealed_boxes.html)
+* [`crypto_generichash`](https://download.libsodium.org/libsodium/content/hashing/generic_hashing.html) (Blake2b)
+* [`crypto_hash`](https://download.libsodium.org/libsodium/content/advanced/sha-2_hash_function.html) (SHA-512-256)
+* [`crypto_onetimeauth`](https://download.libsodium.org/libsodium/content/secret-key_cryptography/chacha20-poly1305.html) (Poly1305)
+* [`crypto_pwhash`](https://download.libsodium.org/libsodium/content/password_hashing/) (Argon2)
+* [`crypto_scalarmult`](https://download.libsodium.org/libsodium/content/advanced/scalar_multiplication.html) (Curve25519)
+* [`crypto_secretbox`](https://download.libsodium.org/libsodium/content/secret-key_cryptography/authenticated_encryption.html)
+* [`crypto_shorthash`](https://download.libsodium.org/libsodium/content/hashing/short-input_hashing.html) (SipHash)
+* [`crypto_sign`](https://download.libsodium.org/libsodium/content/public-key_cryptography/public-key_signatures.html) (Ed25519)
+* [Ed25519->Curve25519 conversion](https://download.libsodium.org/libsodium/content/advanced/ed25519-curve25519.html)
+* [`randombytes`](https://download.libsodium.org/libsodium/content/generating_random_data/)
 
 ## Additional helpers
 
@@ -196,7 +196,7 @@ make libsodium/configure
 
 # Modify the emscripten.sh
 # Specifically, add the name of the missing functions and constants in the "EXPORTED_FUNCTIONS" array.
-# Ensure that the name begins with an underscore and that it is between double quotes. 
+# Ensure that the name begins with an underscore and that it is between double quotes.
 nano libsodium/dist-build/emscripten.sh
 
 # Build libsodium, and then libsodium.js with your chosen functions


### PR DESCRIPTION
doc.libsodium.org is deprecated or something? All of the links that go there
redirect to a generic homepage. Point these links at their new (stable)
locations.