### PR TITLE
Removed deprecated property "version"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "libsodium.js",
-  "version": "0.4.8",
   "homepage": "https://github.com/jedisct1/libsodium.js",
   "authors": [
     "Ahmad Ben Mrad (@BatikhSouri)",


### PR DESCRIPTION
The `version` property in `bower.json` is deprecated: https://github.com/bower/spec/blob/master/json.md#version

Bower uses [GitHub releases](https://github.com/jedisct1/libsodium.js/releases) (Git tags) to find the correct version.

Libsodium.js provides version 0.4.8 through npm but serves only [0.4.2 as a release tag](https://github.com/jedisct1/libsodium.js/releases/tag/0.4.2). This should be in sync.