### PR TITLE
Add return value check for _sodium_init()

### DIFF
--- a/wrapper/wrap-template.js
+++ b/wrapper/wrap-template.js
@@ -18,7 +18,9 @@
 
     var output_format = "uint8array";
 
-    libsodium._sodium_init();
+    if (libsodium._sodium_init() !== 0) {
+        throw new Error("libsodium was not correctly initialized.");
+    }
 
     // List of functions and constants defined in the wrapped libsodium
     function symbols() {


### PR DESCRIPTION
libsodium requires proper initialization in order to behave securely (see [core.c#L39](https://github.com/jedisct1/libsodium/blob/master/src/libsodium/sodium/core.c#L39)).

libsodium.js should therefore verify that the return value of `_sodium_init()` is zero (e.g. [like sodiumoxide does](https://github.com/dnaq/sodiumoxide/blob/master/src/lib.rs#L68)), and return an error otherwise.