### PR TITLE
Add crypto_stream_chacha20_xor

### DIFF
--- a/dist/modules-sumo/libsodium-wrappers-sumo.js
+++ b/dist/modules-sumo/libsodium-wrappers-sumo.js
@@ -3117,6 +3117,110 @@
 		
 	}
 
+    function crypto_stream_chacha20_xor(input_message, nonce, key, outputFormat) {
+        var address_pool = [];
+        _check_output_format(outputFormat);
+
+        // ---------- input: input_message (unsized_buf)
+        
+        input_message = _any_to_Uint8Array(address_pool, input_message, "input_message");
+        var input_message_address = _to_allocated_buf_address(input_message),
+            input_message_length = input_message.length;
+        address_pool.push(input_message_address);
+        
+        // ---------- input: nonce (buf)
+        
+        nonce = _any_to_Uint8Array(address_pool, nonce, "nonce");
+        var nonce_address, nonce_length = (libsodium._crypto_stream_chacha20_noncebytes()) | 0;
+        if (nonce.length !== nonce_length) {
+            _free_and_throw_type_error(address_pool, "invalid nonce length");
+        }
+        nonce_address = _to_allocated_buf_address(nonce);
+        address_pool.push(nonce_address);
+        
+        // ---------- input: key (buf)
+        
+        key = _any_to_Uint8Array(address_pool, key, "key");
+        var key_address, key_length = (libsodium._crypto_stream_chacha20_keybytes()) | 0;
+        if (key.length !== key_length) {
+            _free_and_throw_type_error(address_pool, "invalid key length");
+        }
+        key_address = _to_allocated_buf_address(key);
+        address_pool.push(key_address);
+        
+        // ---------- output output_message (buf)
+        
+        var output_message_length = (input_message_length) | 0,
+            output_message = new AllocatedBuf(output_message_length),
+            output_message_address = output_message.address;
+        
+        address_pool.push(output_message_address);
+        
+        if ((libsodium._crypto_stream_chacha20_xor(output_message_address, input_message_address, input_message_length, 0, nonce_address, key_address)) === 0) {
+            var ret = _format_output(output_message, outputFormat);
+            _free_all(address_pool);
+            return ret;
+        }
+        _free_and_throw_error(address_pool);
+        
+    }
+
+    function crypto_stream_chacha20_xor_ic(input_message, nonce, nonce_increment, key, outputFormat) {
+        var address_pool = [];
+        _check_output_format(outputFormat);
+
+        // ---------- input: input_message (unsized_buf)
+        
+        input_message = _any_to_Uint8Array(address_pool, input_message, "input_message");
+        var input_message_address = _to_allocated_buf_address(input_message),
+            input_message_length = input_message.length;
+        address_pool.push(input_message_address);
+        
+        // ---------- input: nonce (buf)
+        
+        nonce = _any_to_Uint8Array(address_pool, nonce, "nonce");
+        var nonce_address, nonce_length = (libsodium._crypto_stream_chacha20_noncebytes()) | 0;
+        if (nonce.length !== nonce_length) {
+            _free_and_throw_type_error(address_pool, "invalid nonce length");
+        }
+        nonce_address = _to_allocated_buf_address(nonce);
+        address_pool.push(nonce_address);
+        
+        // ---------- input: nonce_increment (uint)
+        
+        _require_defined(address_pool, nonce_increment, "nonce_increment");
+        
+        if (!(typeof nonce_increment === "number" && (nonce_increment | 0) === nonce_increment) && (nonce_increment | 0) > 0) {
+            _free_and_throw_type_error(address_pool, "nonce_increment must be an unsigned integer");
+        }
+        
+        // ---------- input: key (buf)
+        
+        key = _any_to_Uint8Array(address_pool, key, "key");
+        var key_address, key_length = (libsodium._crypto_stream_chacha20_keybytes()) | 0;
+        if (key.length !== key_length) {
+            _free_and_throw_type_error(address_pool, "invalid key length");
+        }
+        key_address = _to_allocated_buf_address(key);
+        address_pool.push(key_address);
+        
+        // ---------- output output_message (buf)
+        
+        var output_message_length = (input_message_length) | 0,
+            output_message = new AllocatedBuf(output_message_length),
+            output_message_address = output_message.address;
+        
+        address_pool.push(output_message_address);
+        
+        if ((libsodium._crypto_stream_chacha20_xor_ic(output_message_address, input_message_address, input_message_length, 0, nonce_address, nonce_increment, 0, key_address)) === 0) {
+            var ret = _format_output(output_message, outputFormat);
+            _free_all(address_pool);
+            return ret;
+        }
+        _free_and_throw_error(address_pool);
+        
+    }
+
 	function randombytes_buf(length, outputFormat) {
 		var address_pool = [];
 		_check_output_format(outputFormat);
@@ -3240,8 +3344,8 @@
     exports.to_string = to_string;
 
     
-	var exported_functions = ["crypto_aead_chacha20poly1305_decrypt", "crypto_aead_chacha20poly1305_decrypt_detached", "crypto_aead_chacha20poly1305_encrypt", "crypto_aead_chacha20poly1305_encrypt_detached", "crypto_aead_chacha20poly1305_ietf_decrypt", "crypto_aead_chacha20poly1305_ietf_decrypt_detached", "crypto_aead_chacha20poly1305_ietf_encrypt", "crypto_aead_chacha20poly1305_ietf_encrypt_detached", "crypto_auth", "crypto_auth_hmacsha256", "crypto_auth_hmacsha256_verify", "crypto_auth_hmacsha512", "crypto_auth_hmacsha512_verify", "crypto_auth_verify", "crypto_box_beforenm", "crypto_box_detached", "crypto_box_easy", "crypto_box_easy_afternm", "crypto_box_keypair", "crypto_box_open_detached", "crypto_box_open_easy", "crypto_box_open_easy_afternm", "crypto_box_seal", "crypto_box_seal_open", "crypto_box_seed_keypair", "crypto_generichash", "crypto_generichash_final", "crypto_generichash_init", "crypto_generichash_update", "crypto_hash", "crypto_hash_sha256", "crypto_hash_sha512", "crypto_onetimeauth", "crypto_onetimeauth_final", "crypto_onetimeauth_init", "crypto_onetimeauth_update", "crypto_onetimeauth_verify", "crypto_pwhash", "crypto_pwhash_scryptsalsa208sha256", "crypto_pwhash_scryptsalsa208sha256_ll", "crypto_pwhash_scryptsalsa208sha256_str", "crypto_pwhash_scryptsalsa208sha256_str_verify", "crypto_pwhash_str", "crypto_pwhash_str_verify", "crypto_scalarmult", "crypto_scalarmult_base", "crypto_secretbox_detached", "crypto_secretbox_easy", "crypto_secretbox_open_detached", "crypto_secretbox_open_easy", "crypto_shorthash", "crypto_sign", "crypto_sign_detached", "crypto_sign_ed25519_pk_to_curve25519", "crypto_sign_ed25519_sk_to_curve25519", "crypto_sign_ed25519_sk_to_pk", "crypto_sign_ed25519_sk_to_seed", "crypto_sign_keypair", "crypto_sign_open", "crypto_sign_seed_keypair", "crypto_sign_verify_detached", "randombytes_buf", "randombytes_close", "randombytes_random", "randombytes_set_implementation", "randombytes_stir", "randombytes_uniform", "sodium_version_string"],
-	      functions = [crypto_aead_chacha20poly1305_decrypt, crypto_aead_chacha20poly1305_decrypt_detached, crypto_aead_chacha20poly1305_encrypt, crypto_aead_chacha20poly1305_encrypt_detached, crypto_aead_chacha20poly1305_ietf_decrypt, crypto_aead_chacha20poly1305_ietf_decrypt_detached, crypto_aead_chacha20poly1305_ietf_encrypt, crypto_aead_chacha20poly1305_ietf_encrypt_detached, crypto_auth, crypto_auth_hmacsha256, crypto_auth_hmacsha256_verify, crypto_auth_hmacsha512, crypto_auth_hmacsha512_verify, crypto_auth_verify, crypto_box_beforenm, crypto_box_detached, crypto_box_easy, crypto_box_easy_afternm, crypto_box_keypair, crypto_box_open_detached, crypto_box_open_easy, crypto_box_open_easy_afternm, crypto_box_seal, crypto_box_seal_open, crypto_box_seed_keypair, crypto_generichash, crypto_generichash_final, crypto_generichash_init, crypto_generichash_update, crypto_hash, crypto_hash_sha256, crypto_hash_sha512, crypto_onetimeauth, crypto_onetimeauth_final, crypto_onetimeauth_init, crypto_onetimeauth_update, crypto_onetimeauth_verify, crypto_pwhash, crypto_pwhash_scryptsalsa208sha256, crypto_pwhash_scryptsalsa208sha256_ll, crypto_pwhash_scryptsalsa208sha256_str, crypto_pwhash_scryptsalsa208sha256_str_verify, crypto_pwhash_str, crypto_pwhash_str_verify, crypto_scalarmult, crypto_scalarmult_base, crypto_secretbox_detached, crypto_secretbox_easy, crypto_secretbox_open_detached, crypto_secretbox_open_easy, crypto_shorthash, crypto_sign, crypto_sign_detached, crypto_sign_ed25519_pk_to_curve25519, crypto_sign_ed25519_sk_to_curve25519, crypto_sign_ed25519_sk_to_pk, crypto_sign_ed25519_sk_to_seed, crypto_sign_keypair, crypto_sign_open, crypto_sign_seed_keypair, crypto_sign_verify_detached, randombytes_buf, randombytes_close, randombytes_random, randombytes_set_implementation, randombytes_stir, randombytes_uniform, sodium_version_string];
+	var exported_functions = ["crypto_aead_chacha20poly1305_decrypt", "crypto_aead_chacha20poly1305_decrypt_detached", "crypto_aead_chacha20poly1305_encrypt", "crypto_aead_chacha20poly1305_encrypt_detached", "crypto_aead_chacha20poly1305_ietf_decrypt", "crypto_aead_chacha20poly1305_ietf_decrypt_detached", "crypto_aead_chacha20poly1305_ietf_encrypt", "crypto_aead_chacha20poly1305_ietf_encrypt_detached", "crypto_auth", "crypto_auth_hmacsha256", "crypto_auth_hmacsha256_verify", "crypto_auth_hmacsha512", "crypto_auth_hmacsha512_verify", "crypto_auth_verify", "crypto_box_beforenm", "crypto_box_detached", "crypto_box_easy", "crypto_box_easy_afternm", "crypto_box_keypair", "crypto_box_open_detached", "crypto_box_open_easy", "crypto_box_open_easy_afternm", "crypto_box_seal", "crypto_box_seal_open", "crypto_box_seed_keypair", "crypto_generichash", "crypto_generichash_final", "crypto_generichash_init", "crypto_generichash_update", "crypto_hash", "crypto_hash_sha256", "crypto_hash_sha512", "crypto_onetimeauth", "crypto_onetimeauth_final", "crypto_onetimeauth_init", "crypto_onetimeauth_update", "crypto_onetimeauth_verify", "crypto_pwhash", "crypto_pwhash_scryptsalsa208sha256", "crypto_pwhash_scryptsalsa208sha256_ll", "crypto_pwhash_scryptsalsa208sha256_str", "crypto_pwhash_scryptsalsa208sha256_str_verify", "crypto_pwhash_str", "crypto_pwhash_str_verify", "crypto_scalarmult", "crypto_scalarmult_base", "crypto_secretbox_detached", "crypto_secretbox_easy", "crypto_secretbox_open_detached", "crypto_secretbox_open_easy", "crypto_shorthash", "crypto_sign", "crypto_sign_detached", "crypto_sign_ed25519_pk_to_curve25519", "crypto_sign_ed25519_sk_to_curve25519", "crypto_sign_ed25519_sk_to_pk", "crypto_sign_ed25519_sk_to_seed", "crypto_sign_keypair", "crypto_sign_open", "crypto_sign_seed_keypair", "crypto_sign_verify_detached", "crypto_stream_chacha20_xor", "crypto_stream_chacha20_xor_ic", "randombytes_buf", "randombytes_close", "randombytes_random", "randombytes_set_implementation", "randombytes_stir", "randombytes_uniform", "sodium_version_string"],
+	      functions = [crypto_aead_chacha20poly1305_decrypt, crypto_aead_chacha20poly1305_decrypt_detached, crypto_aead_chacha20poly1305_encrypt, crypto_aead_chacha20poly1305_encrypt_detached, crypto_aead_chacha20poly1305_ietf_decrypt, crypto_aead_chacha20poly1305_ietf_decrypt_detached, crypto_aead_chacha20poly1305_ietf_encrypt, crypto_aead_chacha20poly1305_ietf_encrypt_detached, crypto_auth, crypto_auth_hmacsha256, crypto_auth_hmacsha256_verify, crypto_auth_hmacsha512, crypto_auth_hmacsha512_verify, crypto_auth_verify, crypto_box_beforenm, crypto_box_detached, crypto_box_easy, crypto_box_easy_afternm, crypto_box_keypair, crypto_box_open_detached, crypto_box_open_easy, crypto_box_open_easy_afternm, crypto_box_seal, crypto_box_seal_open, crypto_box_seed_keypair, crypto_generichash, crypto_generichash_final, crypto_generichash_init, crypto_generichash_update, crypto_hash, crypto_hash_sha256, crypto_hash_sha512, crypto_onetimeauth, crypto_onetimeauth_final, crypto_onetimeauth_init, crypto_onetimeauth_update, crypto_onetimeauth_verify, crypto_pwhash, crypto_pwhash_scryptsalsa208sha256, crypto_pwhash_scryptsalsa208sha256_ll, crypto_pwhash_scryptsalsa208sha256_str, crypto_pwhash_scryptsalsa208sha256_str_verify, crypto_pwhash_str, crypto_pwhash_str_verify, crypto_scalarmult, crypto_scalarmult_base, crypto_secretbox_detached, crypto_secretbox_easy, crypto_secretbox_open_detached, crypto_secretbox_open_easy, crypto_shorthash, crypto_sign, crypto_sign_detached, crypto_sign_ed25519_pk_to_curve25519, crypto_sign_ed25519_sk_to_curve25519, crypto_sign_ed25519_sk_to_pk, crypto_sign_ed25519_sk_to_seed, crypto_sign_keypair, crypto_sign_open, crypto_sign_seed_keypair, crypto_sign_verify_detached, crypto_stream_chacha20_xor, crypto_stream_chacha20_xor_ic, randombytes_buf, randombytes_close, randombytes_random, randombytes_set_implementation, randombytes_stir, randombytes_uniform, sodium_version_string];
 	for (var i = 0; i < functions.length; i++) {
 		if (typeof libsodium["_" + exported_functions[i]] === "function") {
 			exports[exported_functions[i]] = functions[i];

--- a/wrapper/constants.json
+++ b/wrapper/constants.json
@@ -62,5 +62,7 @@
         { "name": "crypto_sign_BYTES", "type": "uint" },
         { "name": "crypto_sign_PUBLICKEYBYTES", "type": "uint" },
         { "name": "crypto_sign_SECRETKEYBYTES", "type": "uint" },
-        { "name": "crypto_sign_SEEDBYTES", "type": "uint" }
+        { "name": "crypto_sign_SEEDBYTES", "type": "uint" },
+        { "name": "crypto_stream_chacha20_KEYBYTES", "type": "uint" },
+        { "name": "crypto_stream_chacha20_NONCEBYTES", "type": "uint" }
 ]

--- a/wrapper/symbols/crypto_stream_chacha20_xor.json
+++ b/wrapper/symbols/crypto_stream_chacha20_xor.json
@@ -1,0 +1,31 @@
+{
+        "name": "crypto_stream_chacha20_xor",
+        "dependencies": ["_crypto_stream_chacha20_noncebytes", "_crypto_stream_chacha20_keybytes"],
+        "type": "function",
+        "inputs": [
+                {
+                        "name": "input_message",
+                        "type": "unsized_buf"
+                },
+                {
+                        "name": "nonce",
+                        "type": "buf",
+                        "size": "libsodium._crypto_stream_chacha20_noncebytes()"
+                },
+                {
+                        "name": "key",
+                        "type": "buf",
+                        "size": "libsodium._crypto_stream_chacha20_keybytes()"
+                }
+        ],
+        "outputs": [
+                {
+                        "name": "output_message",
+                        "type": "buf",
+                        "size": "input_message_length"
+                }
+        ],
+        "target":"libsodium._crypto_stream_chacha20_xor(output_message_address, input_message_address, input_message_length, 0, nonce_address, key_address)",
+        "expect": "=== 0",
+        "return": "_format_output(output_message, outputFormat)"
+}

--- a/wrapper/symbols/crypto_stream_chacha20_xor_ic.json
+++ b/wrapper/symbols/crypto_stream_chacha20_xor_ic.json
@@ -1,0 +1,35 @@
+{
+        "name": "crypto_stream_chacha20_xor_ic",
+        "dependencies": ["_crypto_stream_chacha20_noncebytes", "_crypto_stream_chacha20_keybytes"],
+        "type": "function",
+        "inputs": [
+                {
+                        "name": "input_message",
+                        "type": "unsized_buf"
+                },
+                {
+                        "name": "nonce",
+                        "type": "buf",
+                        "size": "libsodium._crypto_stream_chacha20_noncebytes()"
+                },
+                {
+                        "name": "nonce_increment",
+                        "type": "uint"
+                },
+                {
+                        "name": "key",
+                        "type": "buf",
+                        "size": "libsodium._crypto_stream_chacha20_keybytes()"
+                }
+        ],
+        "outputs": [
+                {
+                        "name": "output_message",
+                        "type": "buf",
+                        "size": "input_message_length"
+                }
+        ],
+        "target":"libsodium._crypto_stream_chacha20_xor_ic(output_message_address, input_message_address, input_message_length, 0, nonce_address, nonce_increment, 0, key_address)",
+        "expect": "=== 0",
+        "return": "_format_output(output_message, outputFormat)"
+}


### PR DESCRIPTION
I added `crypto_stream_chacha20_xor` and `crypto_stream_chacha20_xor_ic` to the `wrappers`, `symbols` and `libsodium-wrappers-sumo.js`.

As I already mentioned in https://github.com/jedisct1/libsodium.js/issues/73#issuecomment-279680119, I don't have a working `emscripten` setup and would ask you to rebuild the `.min.js` files.
I can also provide a test but I'm not sure I quite understand how your test setup works.