### PR TITLE
Added support for “urlsafebase64” and fixed documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If the output is a unique binary buffer, it is returned as a
 
 However, an extra parameter can be given to all wrapped functions, in
 order to specify what format the output should be in. Valid options
-are `uint8array' (default), 'text' and 'hex'.
+are `uint8array' (default), 'text', 'hex', 'base64' and 'urlsafebase64'.
 
 Example (shorthash):
 

--- a/dist/browsers/combined/sodium.js
+++ b/dist/browsers/combined/sodium.js
@@ -306,9 +306,73 @@ return{_sodium_library_version_minor:Re,_sodium_hex2bin:Na,_crypto_pwhash_passwd
         return sB64Enc.substr(0, sB64Enc.length - 2 + nMod3) +
             (nMod3 === 2 ? "" : nMod3 === 1 ? "=" : "==");
     }
+    function from_urlsafebase64(sBase64, nBlocksSize) {
+        function _b64ToUint6(nChr) {
+            return nChr > 64 && nChr < 91 ?
+                nChr - 65 : nChr > 96 && nChr < 123 ?
+                nChr - 71 : nChr > 47 && nChr < 58 ?
+                nChr + 4 : nChr === 45 ?
+                62 : nChr === 95 ?
+                63 :
+                0;
+        }
+
+        var sB64Enc = sBase64.replace(/[^A-Za-z0-9\-\_]/g, ""),
+            nInLen = sB64Enc.length,
+            nOutLen = nBlocksSize ? Math.ceil((nInLen * 3 + 1 >> 2) / nBlocksSize) * nBlocksSize : nInLen * 3 + 1 >> 2,
+            taBytes = new Uint8Array(nOutLen);
+
+        for (var nMod3, nMod4, nUint24 = 0, nOutIdx = 0, nInIdx = 0; nInIdx < nInLen; nInIdx++) {
+            nMod4 = nInIdx & 3;
+            nUint24 |= _b64ToUint6(sB64Enc.charCodeAt(nInIdx)) << 18 - 6 * nMod4;
+            if (nMod4 === 3 || nInLen - nInIdx === 1) {
+                for (nMod3 = 0; nMod3 < 3 && nOutIdx < nOutLen; nMod3++, nOutIdx++) {
+                    taBytes[nOutIdx] = nUint24 >>> (16 >>> nMod3 & 24) & 255;
+                }
+                nUint24 = 0;
+            }
+        }
+        return taBytes;
+    }
+
+    function to_urlsafebase64(aBytes, noNewLine) {
+        if (typeof noNewLine === "undefined") {
+            noNewLine = true;
+        }
+        function _uint6ToB64(nUint6) {
+            return nUint6 < 26 ?
+                nUint6 + 65 : nUint6 < 52 ?
+                nUint6 + 71 : nUint6 < 62 ?
+                nUint6 - 4 : nUint6 === 62 ?
+                45 : nUint6 === 63 ?
+                95 :
+                65;
+        }
+        if (typeof aBytes === "string") {
+            throw new Error("input has to be an array");
+        }
+        var nMod3 = 2,
+            sB64Enc = "";
+        for (var nLen = aBytes.length, nUint24 = 0, nIdx = 0; nIdx < nLen; nIdx++) {
+            nMod3 = nIdx % 3;
+            if (nIdx > 0 && (nIdx * 4 / 3) % 76 === 0 && !noNewLine) {
+                sB64Enc += "\r\n";
+            }
+            nUint24 |= aBytes[nIdx] << (16 >>> nMod3 & 24);
+            if (nMod3 === 2 || aBytes.length - nIdx === 1) {
+                sB64Enc += String.fromCharCode(_uint6ToB64(nUint24 >>> 18 & 63),
+                                               _uint6ToB64(nUint24 >>> 12 & 63),
+                                               _uint6ToB64(nUint24 >>> 6 & 63),
+                                               _uint6ToB64(nUint24 & 63));
+                nUint24 = 0;
+            }
+        }
+        return sB64Enc.substr(0, sB64Enc.length - 2 + nMod3) +
+            (nMod3 === 2 ? "" : nMod3 === 1 ? "=" : "==");
+    }
 
     function output_formats() {
-        return ["uint8array", "text", "hex", "base64"];
+        return ["uint8array", "text", "hex", "base64", "urlsafebase64"];
     }
 
     function _format_output(output, optionalOutputFormat) {
@@ -325,6 +389,8 @@ return{_sodium_library_version_minor:Re,_sodium_hex2bin:Na,_crypto_pwhash_passwd
                 return to_hex(output.to_Uint8Array());
             } else if (selectedOutputFormat === "base64") {
                 return to_base64(output.to_Uint8Array());
+            } else if (selectedOutputFormat === "urlsafebase64") {
+                return to_urlsafebase64(output.to_Uint8Array());
             } else {
                 throw new Error("What is output format \"" + selectedOutputFormat + "\"?");
             }
@@ -4550,6 +4616,7 @@ return{_sodium_library_version_minor:Re,_sodium_hex2bin:Na,_crypto_pwhash_passwd
     exports.add = add;
     exports.compare = compare;
     exports.from_base64 = from_base64;
+    exports.from_urlsafebase64 = from_urlsafebase64;
     exports.from_hex = from_hex;
     exports.from_string = from_string;
     exports.increment = increment;
@@ -4560,6 +4627,7 @@ return{_sodium_library_version_minor:Re,_sodium_hex2bin:Na,_crypto_pwhash_passwd
     exports.output_formats = output_formats;
     exports.symbols = symbols;
     exports.to_base64 = to_base64;
+    exports.to_urlsafebase64 = to_urlsafebase64;
     exports.to_hex = to_hex;
     exports.to_string = to_string;
 

--- a/wrapper/wrap-template.js
+++ b/wrapper/wrap-template.js
@@ -484,6 +484,7 @@
     exports.memzero = memzero;
     exports.output_formats = output_formats;
     exports.symbols = symbols;
+    exports.to_base64 = to_base64;
     exports.to_urlsafebase64 = to_urlsafebase64;
     exports.to_hex = to_hex;
     exports.to_string = to_string;

--- a/wrapper/wrap-template.js
+++ b/wrapper/wrap-template.js
@@ -276,8 +276,74 @@
             (nMod3 === 2 ? "" : nMod3 === 1 ? "=" : "==");
     }
 
+    
+    function from_urlsafebase64(sBase64, nBlocksSize) {
+        function _b64ToUint6(nChr) {
+            return nChr > 64 && nChr < 91 ?
+                nChr - 65 : nChr > 96 && nChr < 123 ?
+                nChr - 71 : nChr > 47 && nChr < 58 ?
+                nChr + 4 : nChr === 45 ?
+                62 : nChr === 95 ?
+                63 :
+                0;
+        }
+
+        var sB64Enc = sBase64.replace(/[^A-Za-z0-9\-\_]/g, ""),
+            nInLen = sB64Enc.length,
+            nOutLen = nBlocksSize ? Math.ceil((nInLen * 3 + 1 >> 2) / nBlocksSize) * nBlocksSize : nInLen * 3 + 1 >> 2,
+            taBytes = new Uint8Array(nOutLen);
+
+        for (var nMod3, nMod4, nUint24 = 0, nOutIdx = 0, nInIdx = 0; nInIdx < nInLen; nInIdx++) {
+            nMod4 = nInIdx & 3;
+            nUint24 |= _b64ToUint6(sB64Enc.charCodeAt(nInIdx)) << 18 - 6 * nMod4;
+            if (nMod4 === 3 || nInLen - nInIdx === 1) {
+                for (nMod3 = 0; nMod3 < 3 && nOutIdx < nOutLen; nMod3++, nOutIdx++) {
+                    taBytes[nOutIdx] = nUint24 >>> (16 >>> nMod3 & 24) & 255;
+                }
+                nUint24 = 0;
+            }
+        }
+        return taBytes;
+    }
+
+    function to_urlsafebase64(aBytes, noNewLine) {
+        if (typeof noNewLine === "undefined") {
+            noNewLine = true;
+        }
+        function _uint6ToB64(nUint6) {
+            return nUint6 < 26 ?
+                nUint6 + 65 : nUint6 < 52 ?
+                nUint6 + 71 : nUint6 < 62 ?
+                nUint6 - 4 : nUint6 === 62 ?
+                45 : nUint6 === 63 ?
+                95 :
+                65;
+        }
+        if (typeof aBytes === "string") {
+            throw new Error("input has to be an array");
+        }
+        var nMod3 = 2,
+            sB64Enc = "";
+        for (var nLen = aBytes.length, nUint24 = 0, nIdx = 0; nIdx < nLen; nIdx++) {
+            nMod3 = nIdx % 3;
+            if (nIdx > 0 && (nIdx * 4 / 3) % 76 === 0 && !noNewLine) {
+                sB64Enc += "\r\n";
+            }
+            nUint24 |= aBytes[nIdx] << (16 >>> nMod3 & 24);
+            if (nMod3 === 2 || aBytes.length - nIdx === 1) {
+                sB64Enc += String.fromCharCode(_uint6ToB64(nUint24 >>> 18 & 63),
+                                               _uint6ToB64(nUint24 >>> 12 & 63),
+                                               _uint6ToB64(nUint24 >>> 6 & 63),
+                                               _uint6ToB64(nUint24 & 63));
+                nUint24 = 0;
+            }
+        }
+        return sB64Enc.substr(0, sB64Enc.length - 2 + nMod3) +
+            (nMod3 === 2 ? "" : nMod3 === 1 ? "=" : "==");
+    }
+
     function output_formats() {
-        return ["uint8array", "text", "hex", "base64"];
+        return ["uint8array", "text", "hex", "base64", "urlsafebase64"];
     }
 
     function _format_output(output, optionalOutputFormat) {
@@ -294,6 +360,8 @@
                 return to_hex(output.to_Uint8Array());
             } else if (selectedOutputFormat === "base64") {
                 return to_base64(output.to_Uint8Array());
+            } else if (selectedOutputFormat === "urlsafebase64") {
+                return to_urlsafebase64(output.to_Uint8Array());
             } else {
                 throw new Error("What is output format \"" + selectedOutputFormat + "\"?");
             }
@@ -406,6 +474,7 @@
     exports.add = add;
     exports.compare = compare;
     exports.from_base64 = from_base64;
+    exports.from_urlsafebase64 = from_urlsafebase64;
     exports.from_hex = from_hex;
     exports.from_string = from_string;
     exports.increment = increment;
@@ -415,7 +484,7 @@
     exports.memzero = memzero;
     exports.output_formats = output_formats;
     exports.symbols = symbols;
-    exports.to_base64 = to_base64;
+    exports.to_urlsafebase64 = to_urlsafebase64;
     exports.to_hex = to_hex;
     exports.to_string = to_string;
 


### PR DESCRIPTION
I've added support for "urlsafebase64" to sodium.js (but not to sodium.min.js) and also fixed README.md (which didn't show support for base64). 

I'm not sure if that matches the plans for what to support in which versions ?

Also - while I can hand edit the dist files and test that way, I'm unable to run the "make" on my Mac, so can't be 100% sure I've correctly edited in "wrapper/wrap-template.js". 

And ... its my first time doing a "Pull Request" so if I'm doing something wrong, please let me know.