### PR TITLE
Asynchronous exports

### DIFF
--- a/wrapper/wrap-template.js
+++ b/wrapper/wrap-template.js
@@ -10,6 +10,8 @@
       if (libsodium._sodium_init() !== 0) {
         throw new Error("libsodium was not correctly initialized.");
       }
+
+      /*{{exports_here}}*/
     });
 
     // List of functions and constants defined in the wrapped libsodium
@@ -570,8 +572,6 @@
     exports.to_base64 = to_base64;
     exports.to_hex = to_hex;
     exports.to_string = to_string;
-
-    /*{{exports_here}}*/
 
     return exports;
   }


### PR DESCRIPTION
Didn't want to conflict with anything you might've been doing for #105 over the last few days @jedisct1, but I just tested locally and everything should work as expected after merging this change and rebuilding with the latest version of my emscripten PR.

My fix was to move up the exports into the `ready` block, so all functions and constants will just be undefined before `ready` is resolved.