### PR TITLE
Fixed syntax error in uglify parsing

### DIFF
--- a/wrapper/libsodium-post.js
+++ b/wrapper/libsodium-post.js
@@ -1,4 +1,4 @@
-    if typeof(process) === 'object' { process.removeAllListeners("uncaughtException"); process.removeAllListeners("unhandledRejection"); }
+    if (typeof(process) === 'object') { process.removeAllListeners("uncaughtException"); process.removeAllListeners("unhandledRejection"); }
     return Module;
 }
 


### PR DESCRIPTION
When running `make`, I get the following error during uglifying:

```
Packing [./dist/modules/libsodium.js]
Parse error at ./dist/modules/libsodium.js:45,7
    if typeof(process) === 'object' { process.removeAllListeners("uncaughtExcept
       ^
ERROR: Unexpected token operator «typeof», expected punc «(»
    at JS_Parse_Error.get (eval at <anonymous> (/[redacted]/libsodium.js/node_modules/uglify-es/tools/node.js:21:1), <anonymous>:75:23)
    at fatal (/[redacted]/libsodium.js/node_modules/uglify-es/bin/uglifyjs:300:53)
    at run (/[redacted]/libsodium.js/node_modules/uglify-es/bin/uglifyjs:239:9)
    at Object.<anonymous> (/[redacted]/libsodium.js/node_modules/uglify-es/bin/uglifyjs:169:5)
    at Module._compile (module.js:643:30)
    at Object.Module._extensions..js (module.js:654:10)
    at Module.load (module.js:556:32)
    at tryModuleLoad (module.js:499:12)
    at Function.Module._load (module.js:491:3)
    at Function.Module.runMain (module.js:684:10)
```

`libsdodium-post.js` is missing two brackets. I am wondering how you were able to compile it :smiley: 