### PR TITLE
Adding wrappers for sha256 and sha512 multipart use case

### DIFF
--- a/wrapper/build-doc.js
+++ b/wrapper/build-doc.js
@@ -89,6 +89,10 @@ exports.buildDocForSymbol = function (s) {
         sDoc += "Unsigned Integer";
       } else if (paramType == "generichash_state_address") {
         sDoc += "Generichash state address";
+      } else if (paramType == "hash_sha256_state_address") {
+        sDoc += "Sha256 state address";
+      } else if (paramType == "hash_sha512_state_address") {
+        sDoc += "Sha512 state address";
       } else if (paramType == "onetimeauth_state_address") {
         sDoc += "OneTimeAuth state address";
       } else if (paramType == "sign_state_address") {
@@ -113,6 +117,10 @@ exports.buildDocForSymbol = function (s) {
           sDoc += "Unsigned Integer";
         } else if (outputType == "generichash_state") {
           sDoc += "Generichash state";
+        } else if (outputType == "hash_sha256_state") {
+          sDoc += "Sha256 state";
+        } else if (outputType == "hash_sha512_state") {
+          sDoc += "Sha512 state";
         } else if (outputType == "onetimeauth_state") {
           sDoc += "OneTimeAuth state";
         } else if (outputType == "sign_state") {

--- a/wrapper/macros/input_hash_sha256_state_address.js
+++ b/wrapper/macros/input_hash_sha256_state_address.js
@@ -1,0 +1,3 @@
+// ---------- input: {var_name} (hash_sha256_state_address)
+
+_require_defined(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_hash_sha512_state_address.js
+++ b/wrapper/macros/input_hash_sha512_state_address.js
@@ -1,0 +1,3 @@
+// ---------- input: {var_name} (hash_sha512_state_address)
+
+_require_defined(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/output_hash_sha256_state.js
+++ b/wrapper/macros/output_hash_sha256_state.js
@@ -1,0 +1,3 @@
+// ---------- output {var_name} (hash_sha256_state)
+
+var {var_name}_address = new AllocatedBuf(104).address;

--- a/wrapper/macros/output_hash_sha512_state.js
+++ b/wrapper/macros/output_hash_sha512_state.js
@@ -1,0 +1,3 @@
+// ---------- output {var_name} (hash_sha512_state)
+
+var {var_name}_address = new AllocatedBuf(208).address;

--- a/wrapper/symbols/crypto_hash_sha256_final.json
+++ b/wrapper/symbols/crypto_hash_sha256_final.json
@@ -1,0 +1,21 @@
+{
+        "name": "crypto_hash_sha256_final",
+        "dependencies": [],
+        "type": "function",
+        "inputs": [
+                {
+                        "name": "state_address",
+                        "type": "hash_sha256_state_address"
+                }
+        ],
+        "outputs": [
+                {
+                        "name": "hash",
+                        "length": "libsodium._crypto_hash_sha256_bytes()",
+                        "type": "buf"
+                }
+        ],
+        "target": "libsodium._crypto_hash_sha256_final(state_address, hash_address) | 0",
+        "assert_retval": [{"condition": "=== 0", "or_else_throw": "invalid usage"}],
+        "return": "(libsodium._free(state_address), _format_output(hash, outputFormat))"
+}

--- a/wrapper/symbols/crypto_hash_sha256_init.json
+++ b/wrapper/symbols/crypto_hash_sha256_init.json
@@ -1,0 +1,14 @@
+{
+        "name": "crypto_hash_sha256_init",
+        "dependencies": [],
+        "type": "function",
+        "outputs": [
+                {
+                        "name": "state",
+                        "type": "hash_sha256_state"
+                }
+        ],
+        "target": "libsodium._crypto_hash_sha256_init(state_address) | 0",
+        "assert_retval": [{"condition": "=== 0", "or_else_throw": "invalid usage"}],
+        "return": "state_address"
+}

--- a/wrapper/symbols/crypto_hash_sha256_update.json
+++ b/wrapper/symbols/crypto_hash_sha256_update.json
@@ -1,0 +1,17 @@
+{
+        "name": "crypto_hash_sha256_update",
+        "dependencies": [],
+        "type": "function",
+        "inputs": [
+                {
+                        "name": "state_address",
+                        "type": "hash_sha256_state_address"
+                },
+                {
+                        "name": "message_chunk",
+                        "type": "unsized_buf"
+                }
+        ],
+        "target": "libsodium._crypto_hash_sha256_update(state_address, message_chunk_address, message_chunk_length) | 0",
+        "assert_retval": [{"condition": "=== 0", "or_else_throw": "invalid usage"}]
+}

--- a/wrapper/symbols/crypto_hash_sha512_final.json
+++ b/wrapper/symbols/crypto_hash_sha512_final.json
@@ -1,0 +1,21 @@
+{
+        "name": "crypto_hash_sha512_final",
+        "dependencies": [],
+        "type": "function",
+        "inputs": [
+                {
+                        "name": "state_address",
+                        "type": "hash_sha512_state_address"
+                }
+        ],
+        "outputs": [
+                {
+                        "name": "hash",
+                        "length": "libsodium._crypto_hash_sha512_bytes()",
+                        "type": "buf"
+                }
+        ],
+        "target": "libsodium._crypto_hash_sha512_final(state_address, hash_address) | 0",
+        "assert_retval": [{"condition": "=== 0", "or_else_throw": "invalid usage"}],
+        "return": "(libsodium._free(state_address), _format_output(hash, outputFormat))"
+}

--- a/wrapper/symbols/crypto_hash_sha512_init.json
+++ b/wrapper/symbols/crypto_hash_sha512_init.json
@@ -1,0 +1,14 @@
+{
+        "name": "crypto_hash_sha512_init",
+        "dependencies": [],
+        "type": "function",
+        "outputs": [
+                {
+                        "name": "state",
+                        "type": "hash_sha512_state"
+                }
+        ],
+        "target": "libsodium._crypto_hash_sha512_init(state_address) | 0",
+        "assert_retval": [{"condition": "=== 0", "or_else_throw": "invalid usage"}],
+        "return": "state_address"
+}

--- a/wrapper/symbols/crypto_hash_sha512_update.json
+++ b/wrapper/symbols/crypto_hash_sha512_update.json
@@ -1,0 +1,17 @@
+{
+        "name": "crypto_hash_sha512_update",
+        "dependencies": [],
+        "type": "function",
+        "inputs": [
+                {
+                        "name": "state_address",
+                        "type": "hash_sha512_state_address"
+                },
+                {
+                        "name": "message_chunk",
+                        "type": "unsized_buf"
+                }
+        ],
+        "target": "libsodium._crypto_hash_sha512_update(state_address, message_chunk_address, message_chunk_length) | 0",
+        "assert_retval": [{"condition": "=== 0", "or_else_throw": "invalid usage"}]
+}


### PR DESCRIPTION
Submitting for review. I wasn't sure if the tests written in `sodium_utils.js` are run with sumo variant, so in the end I didn't add any, but the produced module sumo js seemed to work fine with manual testing.