### PR TITLE
fix: Remove crypto_secretstream_xchacha20poly1305_NPUBBYTES

### DIFF
--- a/wrapper/constants.json
+++ b/wrapper/constants.json
@@ -181,7 +181,6 @@
   { "name": "crypto_secretstream_xchacha20poly1305_HEADERBYTES", "type": "uint" },
   { "name": "crypto_secretstream_xchacha20poly1305_KEYBYTES", "type": "uint" },
   { "name": "crypto_secretstream_xchacha20poly1305_MESSAGEBYTES_MAX", "type": "uint" },
-  { "name": "crypto_secretstream_xchacha20poly1305_NPUBBYTES", "type": "uint" },
   { "name": "crypto_secretstream_xchacha20poly1305_TAG_FINAL", "type": "uint" },
   { "name": "crypto_secretstream_xchacha20poly1305_TAG_MESSAGE", "type": "uint" },
   { "name": "crypto_secretstream_xchacha20poly1305_TAG_PUSH", "type": "uint" },


### PR DESCRIPTION
This removes `crypto_secretstream_xchacha20poly1305_NPUBBYTES` as discussed in https://github.com/jedisct1/libsodium.js/issues/226 since it's not used anywhere.