### PR TITLE
fix crypto_core_ristretto255_scalar_random

### DIFF
--- a/wrapper/symbols/crypto_core_ristretto255_scalar_random.json
+++ b/wrapper/symbols/crypto_core_ristretto255_scalar_random.json
@@ -1,7 +1,8 @@
 {
         "name": "crypto_core_ristretto255_scalar_random",
         "dependencies": [
-                "_crypto_core_ristretto255_scalarbytes"
+                "_crypto_core_ristretto255_scalarbytes",
+                "_crypto_core_ristretto255_scalar_random"
         ],
         "type": "function",
         "inputs": [],
@@ -12,6 +13,6 @@
                         "length": "libsodium._crypto_core_ristretto255_scalarbytes()"
                 }
         ],
-        "target": "libsodium._crypto_core_ristretto255_random(r_address)",
+        "target": "libsodium._crypto_core_ristretto255_scalar_random(r_address)",
         "return": "_format_output(r, outputFormat)"
 }


### PR DESCRIPTION
I found that the name of the function associated with 'crypto_core_ristretto255_scalar_random' is different.
Please review it.