### PR TITLE
Let nodejs process handlers be

### DIFF
--- a/wrapper/libsodium-post.js
+++ b/wrapper/libsodium-post.js
@@ -1,7 +1,3 @@
-    if (typeof(process) === 'object' && typeof(process.removeAllListeners) === 'function') {
-      process.removeAllListeners('uncaughtException');
-      process.removeAllListeners('unhandledRejection');
-    }
     return Module;
 }
 


### PR DESCRIPTION
Building with `NODEJS_CATCH_EXIT=0` and `NODEJS_CATCH_REJECTION=0` tells emscripten to not add the handlers in the first place, so we do not need to compensate after the fact.

Fixes #253