### PR TITLE
Add wrappers for crypto_auth_hmacsha(256|512) multipart

### DIFF
--- a/wrapper/build-doc.js
+++ b/wrapper/build-doc.js
@@ -93,6 +93,8 @@ exports.buildDocForSymbol = function (s) {
         sDoc += "Sha256 state address";
       } else if (paramType == "hash_sha512_state_address") {
         sDoc += "Sha512 state address";
+      } else if (paramType == "auth_hmacsha256_state_address") {
+	sDoc += "Hmac Sha256 state address";
       } else if (paramType == "onetimeauth_state_address") {
         sDoc += "OneTimeAuth state address";
       } else if (paramType == "sign_state_address") {
@@ -121,7 +123,9 @@ exports.buildDocForSymbol = function (s) {
           sDoc += "Sha256 state";
         } else if (outputType == "hash_sha512_state") {
           sDoc += "Sha512 state";
-        } else if (outputType == "onetimeauth_state") {
+        } else if (outputType == "auth_hmacsha256_state") {
+	  sDoc += "Hmac Sha256 state";
+	} else if (outputType == "onetimeauth_state") {
           sDoc += "OneTimeAuth state";
         } else if (outputType == "sign_state") {
           sDoc += "Signature state";

--- a/wrapper/build-doc.js
+++ b/wrapper/build-doc.js
@@ -95,6 +95,8 @@ exports.buildDocForSymbol = function (s) {
         sDoc += "Sha512 state address";
       } else if (paramType == "auth_hmacsha256_state_address") {
 	sDoc += "Hmac Sha256 state address";
+      } else if (paramType == "auth_hmacsha512_state_address") {
+	sDoc += "Hmac Sha512 state address";
       } else if (paramType == "onetimeauth_state_address") {
         sDoc += "OneTimeAuth state address";
       } else if (paramType == "sign_state_address") {
@@ -125,6 +127,8 @@ exports.buildDocForSymbol = function (s) {
           sDoc += "Sha512 state";
         } else if (outputType == "auth_hmacsha256_state") {
 	  sDoc += "Hmac Sha256 state";
+	} else if (outputType == "auth_hmacsha512_state") {
+	  sDoc += "Hmac Sha512 state";
 	} else if (outputType == "onetimeauth_state") {
           sDoc += "OneTimeAuth state";
         } else if (outputType == "sign_state") {

--- a/wrapper/macros/input_auth_hmacsha256_state_address.js
+++ b/wrapper/macros/input_auth_hmacsha256_state_address.js
@@ -1,0 +1,3 @@
+// ---------- input: {var_name} (auth_hmacsha256_state_address)
+
+_require_defined(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_auth_hmacsha512_state_address.js
+++ b/wrapper/macros/input_auth_hmacsha512_state_address.js
@@ -1,0 +1,3 @@
+// ---------- input: {var_name} (auth_hmacsha512_state_address)
+
+_require_defined(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/output_auth_hmacsha256_state.js
+++ b/wrapper/macros/output_auth_hmacsha256_state.js
@@ -1,0 +1,3 @@
+// ---------- output {var_name} (auth_hmacsha256_state)
+
+var {var_name}_address = new AllocatedBuf(208).address;

--- a/wrapper/macros/output_auth_hmacsha512_state.js
+++ b/wrapper/macros/output_auth_hmacsha512_state.js
@@ -1,0 +1,3 @@
+// ---------- output {var_name} (auth_hmacsha512_state)
+
+var {var_name}_address = new AllocatedBuf(416).address;

--- a/wrapper/symbols/crypto_auth_hmacsha256_final.json
+++ b/wrapper/symbols/crypto_auth_hmacsha256_final.json
@@ -1,0 +1,21 @@
+{
+        "name": "crypto_auth_hmacsha256_final",
+        "dependencies": [],
+        "type": "function",
+        "inputs": [
+                {
+                        "name": "state_address",
+                        "type": "auth_hmacsha256_state_address"
+                }
+        ],
+        "outputs": [
+                {
+                        "name": "hash",
+                        "length": "libsodium._crypto_auth_hmacsha256_bytes()",
+                        "type": "buf"
+                }
+        ],
+        "target": "libsodium._crypto_auth_hmacsha256_final(state_address, hash_address) | 0",
+        "assert_retval": [{"condition": "=== 0", "or_else_throw": "invalid usage"}],
+        "return": "(libsodium._free(state_address), _format_output(hash, outputFormat))"
+}

--- a/wrapper/symbols/crypto_auth_hmacsha256_init.json
+++ b/wrapper/symbols/crypto_auth_hmacsha256_init.json
@@ -1,0 +1,20 @@
+{
+        "name": "crypto_auth_hmacsha256_init",
+        "dependencies": [],
+        "type": "function",
+        "inputs": [
+                {
+                        "name": "key",
+                        "type": "unsized_buf_optional"
+                }
+        ],
+        "outputs": [
+                {
+                        "name": "state",
+                        "type": "auth_hmacsha256_state"
+                }
+        ],
+        "target": "libsodium._crypto_auth_hmacsha256_init(state_address, key_address, key_length) | 0",
+        "assert_retval": [{"condition": "=== 0", "or_else_throw": "invalid usage"}],
+        "return": "state_address"
+}

--- a/wrapper/symbols/crypto_auth_hmacsha256_update.json
+++ b/wrapper/symbols/crypto_auth_hmacsha256_update.json
@@ -1,0 +1,17 @@
+{
+        "name": "crypto_auth_hmacsha256_update",
+        "dependencies": [],
+        "type": "function",
+        "inputs": [
+                {
+                        "name": "state_address",
+                        "type": "auth_hmacsha256_state_address"
+                },
+                {
+                        "name": "message_chunk",
+                        "type": "unsized_buf"
+                }
+        ],
+        "target": "libsodium._crypto_auth_hmacsha256_update(state_address, message_chunk_address, message_chunk_length) | 0",
+        "assert_retval": [{"condition": "=== 0", "or_else_throw": "invalid usage"}]
+}

--- a/wrapper/symbols/crypto_auth_hmacsha512_final.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512_final.json
@@ -1,0 +1,21 @@
+{
+        "name": "crypto_auth_hmacsha512_final",
+        "dependencies": [],
+        "type": "function",
+        "inputs": [
+                {
+                        "name": "state_address",
+                        "type": "auth_hmacsha512_state_address"
+                }
+        ],
+        "outputs": [
+                {
+                        "name": "hash",
+                        "length": "libsodium._crypto_auth_hmacsha512_bytes()",
+                        "type": "buf"
+                }
+        ],
+        "target": "libsodium._crypto_auth_hmacsha512_final(state_address, hash_address) | 0",
+        "assert_retval": [{"condition": "=== 0", "or_else_throw": "invalid usage"}],
+        "return": "(libsodium._free(state_address), _format_output(hash, outputFormat))"
+}

--- a/wrapper/symbols/crypto_auth_hmacsha512_init.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512_init.json
@@ -1,0 +1,20 @@
+{
+        "name": "crypto_auth_hmacsha512_init",
+        "dependencies": [],
+        "type": "function",
+        "inputs": [
+                {
+                        "name": "key",
+                        "type": "unsized_buf_optional"
+                }
+        ],
+        "outputs": [
+                {
+                        "name": "state",
+                        "type": "auth_hmacsha512_state"
+                }
+        ],
+        "target": "libsodium._crypto_auth_hmacsha512_init(state_address, key_address, key_length) | 0",
+        "assert_retval": [{"condition": "=== 0", "or_else_throw": "invalid usage"}],
+        "return": "state_address"
+}

--- a/wrapper/symbols/crypto_auth_hmacsha512_update.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512_update.json
@@ -1,0 +1,17 @@
+{
+        "name": "crypto_auth_hmacsha512_update",
+        "dependencies": [],
+        "type": "function",
+        "inputs": [
+                {
+                        "name": "state_address",
+                        "type": "auth_hmacsha512_state_address"
+                },
+                {
+                        "name": "message_chunk",
+                        "type": "unsized_buf"
+                }
+        ],
+        "target": "libsodium._crypto_auth_hmacsha512_update(state_address, message_chunk_address, message_chunk_length) | 0",
+        "assert_retval": [{"condition": "=== 0", "or_else_throw": "invalid usage"}]
+}


### PR DESCRIPTION
Submitting for review. Not sure if any tests are required for the `-sumo` module, I can add them if required. I _believe_ I got the state sizes correctly, manual testing appears to show that it works correctly. Here are the calculations I used to calculate the state size:

**crypto_auth_hmacsha256_state**
```
typedef struct crypto_hash_sha256_state {
    uint32_t state[8];		// 4 * 8
    uint64_t count;		// 8
    uint8_t  buf[64];		// 64
} crypto_hash_sha256_state;	// 104


typedef struct crypto_auth_hmacsha256_state {
    crypto_hash_sha256_state ictx;	// 4 * 8 + 8 + 64
    crypto_hash_sha256_state octx;	// 4 * 8 + 8 + 64
} crypto_auth_hmacsha256_state;		// 208
```

**crypto_auth_hmacsha512_state**
```
typedef struct crypto_hash_sha512_state {
    uint64_t state[8];			// 8 * 8
    uint64_t count[2];			// 8 * 2
    uint8_t  buf[128];			// 128
} crypto_hash_sha512_state;		// 208


typedef struct crypto_auth_hmacsha512_state {
    crypto_hash_sha512_state ictx;	// 8 * 8 + 8 * 2 + 128
    crypto_hash_sha512_state octx;	// 8 * 8 + 8 * 2 + 128
} crypto_auth_hmacsha512_state;		// 416
```
Let me know if any other changes are required.

I am using these right now as the basis for an hkdf algorithm, I noticed that you have a hkdf implementation in the master branch of the libsodium repo (https://github.com/jedisct1/libsodium/tree/master/src/libsodium/crypto_kdf/hkdf) but the pinned version of libsodium doesn't have that yet. Once the pinned version is updated, I'll use that instead of my version.