### PR TITLE
Add crypto_core_hsalsa20

### DIFF
--- a/wrapper/symbols/crypto_core_hsalsa20.json
+++ b/wrapper/symbols/crypto_core_hsalsa20.json
@@ -1,0 +1,36 @@
+{
+  "name": "crypto_core_hsalsa20",
+  "type": "function",
+  "inputs": [
+    {
+      "name": "input",
+      "type": "buf",
+      "length": "libsodium._crypto_core_hsalsa20_inputbytes()"
+    },
+    {
+      "name": "privateKey",
+      "type": "buf",
+      "length": "libsodium._crypto_core_hsalsa20_keybytes()"
+    },
+    {
+      "name": "constant",
+      "type": "unsized_buf_optional",
+      "length": "libsodium._crypto_core_hsalsa20_constbytes()"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "hash",
+      "type": "buf",
+      "length": "libsodium._crypto_core_hsalsa20_outputbytes()"
+    }
+  ],
+  "target": "libsodium._crypto_core_hsalsa20(hash_address, input_address, privateKey_address, constant_address) | 0",
+  "assert_retval": [
+    {
+      "condition": "=== 0",
+      "or_else_throw": "invalid usage"
+    }
+  ],
+  "return": "_format_output(hash, outputFormat)"
+}


### PR DESCRIPTION
I copied the 55e6fe130997cc1734917ca69c6f4f4e444ef437 commit that added chacha20 to include salsa20.  Make rebuilds correctly, and I am able to see the crypto_core_hsalsa20 export and use it.  I didn't include the new dist/ files as the linked commit didn't, but I would ask if we could rebuild and bump the npm version of the library to include these changes.

I am also happy to check in my rebuilt changes.