### PR TITLE
fix: exclude crypto dependency from browser environment

### DIFF
--- a/package-libsodium-sumo.json
+++ b/package-libsodium-sumo.json
@@ -38,6 +38,7 @@
   "browser": {
     "fs": false,
     "path": false,
-    "stream": false
+    "stream": false,
+    "crypto": false
   }
 }

--- a/package-libsodium-wrappers-sumo.json
+++ b/package-libsodium-wrappers-sumo.json
@@ -44,6 +44,7 @@
   "browser": {
     "fs": false,
     "path": false,
-    "stream": false
+    "stream": false,
+    "crypto": false
   }
 }

--- a/package-libsodium-wrappers.json
+++ b/package-libsodium-wrappers.json
@@ -44,6 +44,7 @@
   "browser": {
     "fs": false,
     "path": false,
-    "stream": false
+    "stream": false,
+    "crypto": false
   }
 }

--- a/package-libsodium.json
+++ b/package-libsodium.json
@@ -38,6 +38,7 @@
   "browser": {
     "fs": false,
     "path": false,
-    "stream": false
+    "stream": false,
+    "crypto": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "browser": {
     "fs": false,
     "path": false,
-    "stream": false
+    "stream": false,
+    "crypto": false
   },
   "dependencies": {
     "terser": "^5.37.0"


### PR DESCRIPTION
This PR fixes build errors (e.g. when bundling the wrappers with webpack) by excluding the node `crypto` module from browser environments.

It essentially does the same thing that was done in https://github.com/jedisct1/libsodium.js/commit/c25864a00788831956da88c795ffcff535f16b8d to fix https://github.com/jedisct1/libsodium.js/issues/309, or in https://github.com/jedisct1/libsodium.js/commit/a8ea20ffab2c5ef39d766d84100b73bad972b209 to fix https://github.com/jedisct1/libsodium.js/issues/99.

---

Without this change, the following error occurs when bundling with webpack:
```
Module build failed: Module not found:
"./node_modules/libsodium-sumo/dist/modules-sumo/libsodium-sumo.js" contains a reference to the file "crypto".
This file can not be found, please check it for typos or update it if the file got moved.
```