### PR TITLE
fix: use URL for calculating __dirname polyfill

### DIFF
--- a/wrapper/libsodium-esm-pre.js
+++ b/wrapper/libsodium-esm-pre.js
@@ -3,8 +3,9 @@
 // Using the standard URL API which is available globally in both Node.js and browsers - no imports needed
 var __filename, __dirname;
 if (typeof import.meta !== 'undefined' && import.meta.url) {
-  __filename = new URL(import.meta.url).pathname;
-  __dirname = new URL('.', import.meta.url).pathname;
+  const url = new URL(import.meta.url)
+  __filename = url.pathname;
+  __dirname = new URL('.', url).pathname;
 }
 
 var Module = {};


### PR DESCRIPTION
Thank you for your very quick fixes, I believe this is the last one to make everything work with webpack.

Apparently you can't use a string as the second parameter for the `__dirname` polyfill. That causes webpack to throw the following cryptic error:

```
"./node_modules/libsodium-sumo/dist/modules-sumo-esm/libsodium-sumo.mjs" contains a reference to the file ".".
This file can not be found, please check it for typos or update it if the file got moved.
```

Changing it to an URL object fixes that, and I don't get any more warnings or errors.

---

PS: I don't really know how to use the ESM exports yet. All the helpers (like `from_hex`) work fine, but I don't know how to actually import the libsodium functions. Are they properties of the `libsodium` export? I think an example would be great, and I'd be happy to contribute one once I figure out how it works :P

```
export 'crypto_generichash_BYTES' (imported as 'crypto_generichash_BYTES') was not found in 'libsodium-wrappers-sumo' (possible exports: add, base64_variants, compare, default, from_base64, from_hex, from_string, increment, is_zero, libsodium, memcmp, memzero, output_formats, pad, ready, symbols, to_base64, to_hex, to_string, unpad)
```