### PR TITLE
added input_ranged_uint macro for clearer error messages

### DIFF
--- a/test/hash.test.ts
+++ b/test/hash.test.ts
@@ -61,6 +61,49 @@ test("crypto_generichash2", () => {
 	expect(mac3).not.toEqual(mac1);
 });
 
+test("crypto_generichash rejects out-of-range hash_length", () => {
+	const message = sodium.from_string("hello");
+
+	// Confirm errors
+	expect(() =>
+		sodium.crypto_generichash(
+			sodium.crypto_generichash_BYTES_MIN - 1,
+			message,
+		),
+	).toThrow();
+	expect(() =>
+		sodium.crypto_generichash(
+			sodium.crypto_generichash_BYTES_MAX + 1,
+			message,
+		),
+	).toThrow();
+	expect(() =>
+		sodium.crypto_generichash_init(
+			null,
+			sodium.crypto_generichash_BYTES_MIN - 1,
+		),
+	).toThrow();
+	expect(() =>
+		sodium.crypto_generichash_init(
+			null,
+			sodium.crypto_generichash_BYTES_MAX + 1,
+		),
+	).toThrow();
+
+	// Boundary values succeed
+	const min_hash = sodium.crypto_generichash(
+		sodium.crypto_generichash_BYTES_MIN,
+		message,
+	);
+	expect(min_hash.length).toBe(sodium.crypto_generichash_BYTES_MIN);
+
+	const max_hash = sodium.crypto_generichash(
+		sodium.crypto_generichash_BYTES_MAX,
+		message,
+	);
+	expect(max_hash.length).toBe(sodium.crypto_generichash_BYTES_MAX);
+});
+
 // SHA-256 Tests
 
 test("crypto_hash_sha256 - one-shot basic", () => {

--- a/wrapper/build-wrappers.ts
+++ b/wrapper/build-wrappers.ts
@@ -141,6 +141,12 @@ class WrapperBuilder {
 		if (variable.min_length !== undefined) {
 			result = result.split("{var_min_length}").join(variable.min_length);
 		}
+		if (variable.min_value !== undefined) {
+			result = result.split("{var_min_value}").join(variable.min_value);
+		}
+		if (variable.max_value !== undefined) {
+			result = result.split("{var_max_value}").join(variable.max_value);
+		}
 		return result;
 	}
 

--- a/wrapper/macros/input_ranged_uint.js
+++ b/wrapper/macros/input_ranged_uint.js
@@ -1,0 +1,12 @@
+// ---------- input: {var_name} (ranged_uint)
+
+_require_defined(address_pool, {var_name}, "{var_name}");
+
+if (!(typeof {var_name} === "number" && ({var_name} | 0) === {var_name}) || {var_name} < 0) {
+        _free_and_throw_type_error(address_pool, "{var_name} must be an unsigned integer");
+}
+
+var {var_name}_min_value = {var_min_value}, {var_name}_max_value = {var_max_value};
+if ({var_name} < {var_name}_min_value || {var_name} > {var_name}_max_value) {
+        _free_and_throw_type_error(address_pool, "{var_name} must be >= " + {var_name}_min_value + " and <= " + {var_name}_max_value);
+}

--- a/wrapper/shared-types.ts
+++ b/wrapper/shared-types.ts
@@ -27,6 +27,7 @@ export const INPUT_TYPES = {
 		description: "Optional fixed-size buffer",
 	},
 	uint: { ts: "number", doc: "number", description: "Unsigned integer" },
+	ranged_uint: { ts: "number", doc: "number", description: "Range bound unsigned integer" },
 	u64: {
 		ts: "number | bigint",
 		doc: "number | bigint",

--- a/wrapper/symbols/crypto_generichash.json
+++ b/wrapper/symbols/crypto_generichash.json
@@ -4,7 +4,9 @@
   "inputs": [
     {
       "name": "hash_length",
-      "type": "uint"
+      "type": "ranged_uint",
+      "min_value": "libsodium._crypto_generichash_bytes_min()",
+      "max_value": "libsodium._crypto_generichash_bytes_max()"
     },
     {
       "name": "message",

--- a/wrapper/symbols/crypto_generichash_blake2b_salt_personal.json
+++ b/wrapper/symbols/crypto_generichash_blake2b_salt_personal.json
@@ -4,7 +4,9 @@
   "inputs": [
     {
       "name": "subkey_len",
-      "type": "uint"
+      "type": "ranged_uint",
+      "min_value": "libsodium._crypto_generichash_bytes_min()",
+      "max_value": "libsodium._crypto_generichash_bytes_max()"
     },
     {
       "name": "key",

--- a/wrapper/symbols/crypto_generichash_final.json
+++ b/wrapper/symbols/crypto_generichash_final.json
@@ -8,7 +8,9 @@
     },
     {
       "name": "hash_length",
-      "type": "uint"
+      "type": "ranged_uint",
+      "min_value": "libsodium._crypto_generichash_bytes_min()",
+      "max_value": "libsodium._crypto_generichash_bytes_max()"
     }
   ],
   "outputs": [

--- a/wrapper/symbols/crypto_generichash_init.json
+++ b/wrapper/symbols/crypto_generichash_init.json
@@ -8,7 +8,9 @@
     },
     {
       "name": "hash_length",
-      "type": "uint"
+      "type": "ranged_uint",
+      "min_value": "libsodium._crypto_generichash_bytes_min()",
+      "max_value": "libsodium._crypto_generichash_bytes_max()"
     }
   ],
   "outputs": [

--- a/wrapper/symbols/crypto_kdf_derive_from_key.json
+++ b/wrapper/symbols/crypto_kdf_derive_from_key.json
@@ -4,7 +4,9 @@
   "inputs": [
     {
       "name": "subkey_len",
-      "type": "uint"
+      "type": "ranged_uint",
+      "min_value": "libsodium._crypto_kdf_bytes_min()",
+      "max_value": "libsodium._crypto_kdf_bytes_max()"
     },
     {
       "name": "subkey_id",

--- a/wrapper/types.ts
+++ b/wrapper/types.ts
@@ -3,6 +3,8 @@ export interface SymbolInput {
 	type: string;
 	length?: string;
 	min_length?: string;
+	min_value?: string;
+	max_value?: string;
 	size?: string;
 }
 


### PR DESCRIPTION
While looking into issue #370 I noticed input values that have well defined ranges are not checked by the wrapper, missing an opportunity to throw clearer error messages. Here is a proposal