### PR TITLE
removed dead dependencies from hmac symbols

### DIFF
--- a/wrapper/symbols/crypto_auth_hmacsha256_final.json
+++ b/wrapper/symbols/crypto_auth_hmacsha256_final.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha256_final",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha256_init.json
+++ b/wrapper/symbols/crypto_auth_hmacsha256_init.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha256_init",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha256_update.json
+++ b/wrapper/symbols/crypto_auth_hmacsha256_update.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha256_update",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha512256_final.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512256_final.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha512256_final",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha512256_init.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512256_init.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha512256_init",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha512256_update.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512256_update.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha512256_update",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha512_final.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512_final.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha512_final",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha512_init.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512_init.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha512_init",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha512_update.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512_update.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha512_update",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {


### PR DESCRIPTION
This is cleanup for a follow-on PR that will check function symbol validity.