### PR TITLE
reject unknown top-level keys in symbols

### DIFF
--- a/test/symbols.test.ts
+++ b/test/symbols.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+
+import sealOpenSymbol from "../wrapper/symbols/crypto_box_seal_open.json";
+
+import {
+	type ConstantSymbol,
+	checkFunctionSymbol,
+	type FunctionSymbol,
+} from "../wrapper/types.ts";
+
+test("checkFunctionSymbol accepts a valid symbol", () => {
+	const symbol: FunctionSymbol = sealOpenSymbol;
+	const result = checkFunctionSymbol(symbol);
+	expect(result.valid).toBe(true);
+	expect(result.error).toBe("");
+});
+
+test("checkFunctionSymbol rejects a symbol with 'expect' key", () => {
+	const symbol: FunctionSymbol = { ...sealOpenSymbol, expect: "=== 0" };
+	const result = checkFunctionSymbol(symbol);
+	expect(result.valid).toBe(false);
+	expect(result.error).toBe("invalid symbol: expect");
+});
+
+test("checkFunctionSymbol rejects a non-function symbol", () => {
+	const symbol: ConstantSymbol = {
+		name: "SODIUM_VERSION_STRING",
+		type: "constant",
+	};
+	const result = checkFunctionSymbol(symbol);
+	expect(result.valid).toBe(false);
+	expect(result.error).toBe("not a function");
+});

--- a/wrapper/build-doc.ts
+++ b/wrapper/build-doc.ts
@@ -17,7 +17,7 @@ import type {
 	SymbolInput,
 	SymbolOutput,
 } from "./types.ts";
-import { isFunctionSymbol } from "./types.ts";
+import { checkFunctionSymbol } from "./types.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -28,7 +28,7 @@ function loadSymbols(symbolsDir: string): FunctionSymbol[] {
 	for (const file of files.sort()) {
 		const content = fs.readFileSync(path.join(symbolsDir, file), "utf8");
 		const symbol = JSON.parse(content);
-		if (isFunctionSymbol(symbol)) {
+		if (checkFunctionSymbol(symbol).valid) {
 			symbols.push(symbol);
 		}
 	}

--- a/wrapper/build-typescript-defs.ts
+++ b/wrapper/build-typescript-defs.ts
@@ -11,7 +11,7 @@ import {
 	parseReturnType,
 } from "./shared-types.ts";
 import type { Constant, FunctionSymbol } from "./types.ts";
-import { isFunctionSymbol } from "./types.ts";
+import { checkFunctionSymbol } from "./types.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -322,7 +322,7 @@ function loadSymbols(symbolsDir: string): FunctionSymbol[] {
 	for (const file of files.sort()) {
 		const content = fs.readFileSync(path.join(symbolsDir, file), "utf8");
 		const symbol = JSON.parse(content);
-		if (isFunctionSymbol(symbol)) {
+		if (checkFunctionSymbol(symbol).valid) {
 			symbols.push(symbol);
 		}
 	}

--- a/wrapper/build-wrappers.ts
+++ b/wrapper/build-wrappers.ts
@@ -9,7 +9,7 @@ import type {
 	SymbolInput,
 	SymbolOutput,
 } from "./types.ts";
-import { isFunctionSymbol } from "./types.ts";
+import { checkFunctionSymbol } from "./types.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -325,10 +325,11 @@ function loadSymbols(): FunctionSymbol[] {
 			process.exit(1);
 		}
 
-		if (isFunctionSymbol(symbol as FunctionSymbol)) {
+		const check = checkFunctionSymbol(symbol as FunctionSymbol);
+		if (check.valid) {
 			symbols.push(symbol as FunctionSymbol);
 		} else {
-			console.error(`Unknown symbol type in ${file}`);
+			console.error(`${file}: ${check.error}`);
 			process.exit(1);
 		}
 	}

--- a/wrapper/symbols/crypto_auth_hmacsha256_final.json
+++ b/wrapper/symbols/crypto_auth_hmacsha256_final.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha256_final",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha256_init.json
+++ b/wrapper/symbols/crypto_auth_hmacsha256_init.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha256_init",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha256_update.json
+++ b/wrapper/symbols/crypto_auth_hmacsha256_update.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha256_update",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha512256_final.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512256_final.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha512256_final",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha512256_init.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512256_init.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha512256_init",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha512256_update.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512256_update.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha512256_update",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha512_final.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512_final.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha512_final",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha512_init.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512_init.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha512_init",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/symbols/crypto_auth_hmacsha512_update.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512_update.json
@@ -1,6 +1,5 @@
 {
   "name": "crypto_auth_hmacsha512_update",
-  "dependencies": [],
   "type": "function",
   "inputs": [
     {

--- a/wrapper/types.ts
+++ b/wrapper/types.ts
@@ -44,7 +44,7 @@ export interface Constant {
 	type: "uint" | "string";
 }
 
-export const FUNCTION_SYMBOLS = new Set<string>([
+export const FUNCTION_SYMBOL_KEYS = new Set<string>([
 	"name",
 	"type",
 	"inputs",
@@ -63,7 +63,7 @@ export function checkFunctionSymbol(symbol: LibsodiumSymbol): {
 		return { valid: false, error: "not a function" };
 	}
 	for (const key of Object.keys(symbol)) {
-		if (!FUNCTION_SYMBOLS.has(key)) {
+		if (!FUNCTION_SYMBOL_KEYS.has(key)) {
 			return { valid: false, error: `invalid symbol: ${key}` };
 		}
 	}

--- a/wrapper/types.ts
+++ b/wrapper/types.ts
@@ -44,8 +44,28 @@ export interface Constant {
 	type: "uint" | "string";
 }
 
-export function isFunctionSymbol(
-	symbol: LibsodiumSymbol,
-): symbol is FunctionSymbol {
-	return symbol.type === "function";
+export const FUNCTION_SYMBOLS = new Set<string>([
+	"name",
+	"type",
+	"inputs",
+	"outputs",
+	"target",
+	"return",
+	"noOutputFormat",
+	"assert_retval",
+]);
+
+export function checkFunctionSymbol(symbol: LibsodiumSymbol): {
+	valid: boolean;
+	error: string;
+} {
+	if (symbol.type !== "function") {
+		return { valid: false, error: "not a function" };
+	}
+	for (const key of Object.keys(symbol)) {
+		if (!FUNCTION_SYMBOLS.has(key)) {
+			return { valid: false, error: `invalid symbol: ${key}` };
+		}
+	}
+	return { valid: true, error: "" };
 }


### PR DESCRIPTION
Meant to provide a safety net to detect invalid symbols more often. This does create a maintenance burden of needing to remember to remove keys from FUNCTION_SYMBOL_KEYS when key no longer exists (likely rare).  Adding keys w/o updating FUNCTION_SYMBOL_KEYS will be obvious.

Please merge PR #373 first, then this diff should shrink. 