### PR TITLE
use proper fixed length inputs on several functions

### DIFF
--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -29,3 +29,34 @@ test("crypto_core_hsalsa20 checks optional constant length", () => {
 		sodium.crypto_core_hsalsa20(input, key, constant.slice(1)),
 	).toThrow();
 });
+
+test("crypto_core_ed25519_from_uniform checks input length", () => {
+	const uniform = new Uint8Array(sodium.crypto_core_ed25519_UNIFORMBYTES);
+
+	expect(sodium.crypto_core_ed25519_from_uniform(uniform).length).toBe(
+		sodium.crypto_core_ed25519_BYTES,
+	);
+	expect(() =>
+		sodium.crypto_core_ed25519_from_uniform(uniform.slice(1)),
+	).toThrow();
+});
+
+test("crypto_core_ed25519_from_hash checks input length", () => {
+	const hash = new Uint8Array(sodium.crypto_core_ed25519_HASHBYTES);
+
+	expect(sodium.crypto_core_ed25519_from_hash(hash).length).toBe(
+		sodium.crypto_core_ed25519_BYTES,
+	);
+	expect(() => sodium.crypto_core_ed25519_from_hash(hash.slice(1))).toThrow();
+});
+
+test("crypto_core_ristretto255_from_hash checks input length", () => {
+	const hash = new Uint8Array(sodium.crypto_core_ristretto255_HASHBYTES);
+
+	expect(sodium.crypto_core_ristretto255_from_hash(hash).length).toBe(
+		sodium.crypto_core_ristretto255_BYTES,
+	);
+	expect(() =>
+		sodium.crypto_core_ristretto255_from_hash(hash.slice(1)),
+	).toThrow();
+});

--- a/test/onetimeauth.test.ts
+++ b/test/onetimeauth.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test";
+
+import { init } from "./test_helper.ts";
+
+const sodium = await init();
+
+test("crypto_onetimeauth_init checks key length", () => {
+	const key = new Uint8Array(sodium.crypto_onetimeauth_KEYBYTES);
+
+	expect(() => sodium.crypto_onetimeauth_init(key)).not.toThrow();
+	expect(() => sodium.crypto_onetimeauth_init(key.slice(1))).toThrow();
+});
+
+test("crypto_onetimeauth_init requires a key", () => {
+	expect(() => sodium.crypto_onetimeauth_init()).toThrow();
+	expect(() => sodium.crypto_onetimeauth_init(null)).toThrow();
+});

--- a/wrapper/symbols/crypto_core_ed25519_from_hash.json
+++ b/wrapper/symbols/crypto_core_ed25519_from_hash.json
@@ -4,7 +4,8 @@
   "inputs": [
     {
       "name": "r",
-      "type": "unsized_buf"
+      "type": "buf",
+      "length": "libsodium._crypto_core_ed25519_hashbytes()"
     }
   ],
   "outputs": [

--- a/wrapper/symbols/crypto_core_ed25519_from_uniform.json
+++ b/wrapper/symbols/crypto_core_ed25519_from_uniform.json
@@ -4,7 +4,8 @@
   "inputs": [
     {
       "name": "r",
-      "type": "unsized_buf"
+      "type": "buf",
+      "length": "libsodium._crypto_core_ed25519_uniformbytes()"
     }
   ],
   "outputs": [

--- a/wrapper/symbols/crypto_core_ristretto255_from_hash.json
+++ b/wrapper/symbols/crypto_core_ristretto255_from_hash.json
@@ -4,7 +4,8 @@
   "inputs": [
     {
       "name": "r",
-      "type": "unsized_buf"
+      "type": "buf",
+      "length": "libsodium._crypto_core_ristretto255_hashbytes()"
     }
   ],
   "outputs": [

--- a/wrapper/symbols/crypto_onetimeauth_init.json
+++ b/wrapper/symbols/crypto_onetimeauth_init.json
@@ -4,7 +4,8 @@
   "inputs": [
     {
       "name": "key",
-      "type": "unsized_buf_optional"
+      "type": "buf",
+      "length": "libsodium._crypto_onetimeauth_keybytes()"
     }
   ],
   "outputs": [


### PR DESCRIPTION
All 4 tests failed before this fix resulting in uninitialized memory access. 

This PR includes a fix for the  deprecated crypto_core_ed25519_from_hash because it is still exported.