### PR TITLE
expand state address validation

### DIFF
--- a/test/state-addresses.test.ts
+++ b/test/state-addresses.test.ts
@@ -10,7 +10,7 @@ test("free rejects invalid addresses", () => {
 	}
 });
 
-test("crypto_sign_update rejects invalid state_address values", () => {
+test("crypto_sign_update rejects addresses", () => {
 	const message = sodium.from_string("hello");
 	for (const bad of [undefined, null, NaN, 0, -1, 1.5, "foo", true]) {
 		expect(() => sodium.crypto_sign_update(bad, message)).toThrow(TypeError);

--- a/test/state-addresses.test.ts
+++ b/test/state-addresses.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+
+import { init } from "./test_helper.ts";
+
+const sodium = await init();
+
+test("free rejects invalid addresses", () => {
+	for (const bad of [undefined, null, NaN, 0, -1, 1.5, "foo", true]) {
+		expect(() => sodium.free(bad)).toThrow(TypeError);
+	}
+});
+
+test("crypto_sign_update rejects invalid state_address values", () => {
+	const message = sodium.from_string("hello");
+	for (const bad of [undefined, null, NaN, 0, -1, 1.5, "foo", true]) {
+		expect(() => sodium.crypto_sign_update(bad, message)).toThrow(TypeError);
+	}
+});

--- a/wrapper/macros/input_auth_hmacsha256_state_address.js
+++ b/wrapper/macros/input_auth_hmacsha256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (auth_hmacsha256_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_auth_hmacsha512256_state_address.js
+++ b/wrapper/macros/input_auth_hmacsha512256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (auth_hmacsha512256_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_auth_hmacsha512_state_address.js
+++ b/wrapper/macros/input_auth_hmacsha512_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (auth_hmacsha512_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_generichash_state_address.js
+++ b/wrapper/macros/input_generichash_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (generichash_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_hash_sha256_state_address.js
+++ b/wrapper/macros/input_hash_sha256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (hash_sha256_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_hash_sha3256_state_address.js
+++ b/wrapper/macros/input_hash_sha3256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (hash_sha3256_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_hash_sha3512_state_address.js
+++ b/wrapper/macros/input_hash_sha3512_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (hash_sha3512_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_hash_sha512_state_address.js
+++ b/wrapper/macros/input_hash_sha512_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (hash_sha512_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_onetimeauth_state_address.js
+++ b/wrapper/macros/input_onetimeauth_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (onetimeauth_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_secretstream_xchacha20poly1305_state_address.js
+++ b/wrapper/macros/input_secretstream_xchacha20poly1305_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (secretstream_xchacha20poly1305_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_sign_state_address.js
+++ b/wrapper/macros/input_sign_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (sign_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_xof_shake128_state_address.js
+++ b/wrapper/macros/input_xof_shake128_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (xof_shake128_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_xof_shake256_state_address.js
+++ b/wrapper/macros/input_xof_shake256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (xof_shake256_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_xof_turboshake128_state_address.js
+++ b/wrapper/macros/input_xof_turboshake128_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (xof_turboshake128_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_xof_turboshake256_state_address.js
+++ b/wrapper/macros/input_xof_turboshake256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (xof_turboshake256_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/wrap-esm-template.js
+++ b/wrapper/wrap-esm-template.js
@@ -78,13 +78,7 @@ function symbols() {
 }
 
 function free(state_address) {
-  if (
-    typeof state_address !== "number" ||
-    !isFinite(state_address) ||
-    state_address <= 0
-  ) {
-    throw new TypeError("state_address must be a valid StateAddress");
-  }
+  _require_address(null, state_address, "state_address");
   _free(state_address);
 }
 
@@ -581,6 +575,20 @@ function _require_defined(address_pool, varValue, varName) {
     _free_and_throw_type_error(
       address_pool,
       varName + " cannot be null or undefined"
+    );
+  }
+}
+
+function _require_address(address_pool, varValue, varName) {
+  _require_defined(address_pool, varValue, varName);
+  if (
+    typeof varValue !== "number" ||
+    !Number.isInteger(varValue) ||
+    varValue <= 0 || varValue > 0xffffffff
+  ) {
+    _free_and_throw_type_error(
+      address_pool,
+      varName + " is not a valid address"
     );
   }
 }

--- a/wrapper/wrap-template.js
+++ b/wrapper/wrap-template.js
@@ -47,13 +47,7 @@
     }
 
     function free(state_address) {
-      if (
-        typeof state_address !== "number" ||
-        !isFinite(state_address) ||
-        state_address <= 0
-      ) {
-        throw new TypeError("state_address must be a valid StateAddress");
-      }
+      _require_address(null, state_address, "state_address");
       _free(state_address);
     }
 
@@ -571,6 +565,20 @@
         _free_and_throw_type_error(
           address_pool,
           varName + " cannot be null or undefined"
+        );
+      }
+    }
+
+    function _require_address(address_pool, varValue, varName) {
+      _require_defined(address_pool, varValue, varName);
+      if (
+        typeof varValue !== "number" ||
+        !Number.isInteger(varValue) ||
+        varValue <= 0 || varValue > 0xffffffff
+      ) {
+        _free_and_throw_type_error(
+          address_pool,
+          varName + " is not a valid address"
         );
       }
     }


### PR DESCRIPTION
* macro controlled state_address inputs now use the same validation as free()
* tightened state_address value constraints (valid for wasm32 and wasm64 which both have 4GB JS cap)