### PR TITLE
Feat/state address tracking

### DIFF
--- a/test/state-addresses.test.ts
+++ b/test/state-addresses.test.ts
@@ -10,9 +10,67 @@ test("free rejects invalid addresses", () => {
 	}
 });
 
-test("crypto_sign_update rejects addresses", () => {
+test("crypto_xof_shake128_update rejects invalid addresses", () => {
 	const message = sodium.from_string("hello");
 	for (const bad of [undefined, null, NaN, 0, -1, 1.5, "foo", true]) {
-		expect(() => sodium.crypto_sign_update(bad, message)).toThrow(TypeError);
+		expect(() => sodium.crypto_xof_shake128_update(bad, message)).toThrow(
+			TypeError,
+		);
 	}
+});
+
+test("free accepts valid state", () => {
+	const state = sodium.crypto_xof_shake128_init();
+	expect(() => sodium.free(state)).not.toThrow();
+});
+
+test("free rejects double-free", () => {
+	const state = sodium.crypto_xof_shake128_init();
+	sodium.free(state);
+	expect(() => sodium.free(state)).toThrow(Error);
+});
+
+test("free rejects untracked state", () => {
+	const garbage = sodium.libsodium._malloc(256);
+	expect(() => sodium.free(garbage)).toThrow(Error);
+	sodium.libsodium._free(garbage);
+});
+
+test("crypto_xof_shake128_update rejects untracked state", () => {
+	const garbage = sodium.libsodium._malloc(256);
+	const message = sodium.from_string("hello");
+	expect(() => sodium.crypto_xof_shake128_update(garbage, message)).toThrow(
+		Error,
+	);
+	sodium.libsodium._free(garbage);
+});
+
+test("crypto_xof_shake128_update rejects freed state", () => {
+	const message = sodium.from_string("hello");
+	const state = sodium.crypto_xof_shake128_init();
+	sodium.free(state);
+	expect(() => sodium.crypto_xof_shake128_update(state, message)).toThrow(
+		Error,
+	);
+});
+
+test("crypto_sign_final_create accepts valid state", () => {
+	const message = sodium.from_string("hello");
+	const keypair = sodium.crypto_sign_keypair();
+	const state = sodium.crypto_sign_init();
+	sodium.crypto_sign_update(state, message);
+	expect(() =>
+		sodium.crypto_sign_final_create(state, keypair.privateKey),
+	).not.toThrow();
+});
+
+test("crypto_sign_final_create rejects double-final", () => {
+	const message = sodium.from_string("hello");
+	const keypair = sodium.crypto_sign_keypair();
+	const state = sodium.crypto_sign_init();
+	sodium.crypto_sign_update(state, message);
+	sodium.crypto_sign_final_create(state, keypair.privateKey);
+	expect(() =>
+		sodium.crypto_sign_final_create(state, keypair.privateKey),
+	).toThrow(Error);
 });

--- a/test/state-addresses.test.ts
+++ b/test/state-addresses.test.ts
@@ -10,7 +10,7 @@ test("free rejects invalid addresses", () => {
 	}
 });
 
-test("crypto_sign_update rejects invalid state_address values", () => {
+test("crypto_sign_update rejects addresses", () => {
 	const message = sodium.from_string("hello");
 	for (const bad of [undefined, null, NaN, 0, -1, 1.5, "foo", true]) {
 		expect(() => sodium.crypto_sign_update(bad, message)).toThrow(TypeError);

--- a/test/state-addresses.test.ts
+++ b/test/state-addresses.test.ts
@@ -36,6 +36,16 @@ test("free rejects untracked state", () => {
 	sodium.libsodium._free(garbage);
 });
 
+test("crypto_sign_final_create accepts valid state", () => {
+	const message = sodium.from_string("hello");
+	const keypair = sodium.crypto_sign_keypair();
+	const state = sodium.crypto_sign_init();
+	sodium.crypto_sign_update(state, message);
+	expect(() =>
+		sodium.crypto_sign_final_create(state, keypair.privateKey),
+	).not.toThrow();
+});
+
 test("crypto_xof_shake128_update rejects untracked state", () => {
 	const garbage = sodium.libsodium._malloc(256);
 	const message = sodium.from_string("hello");
@@ -52,16 +62,6 @@ test("crypto_xof_shake128_update rejects freed state", () => {
 	expect(() => sodium.crypto_xof_shake128_update(state, message)).toThrow(
 		Error,
 	);
-});
-
-test("crypto_sign_final_create accepts valid state", () => {
-	const message = sodium.from_string("hello");
-	const keypair = sodium.crypto_sign_keypair();
-	const state = sodium.crypto_sign_init();
-	sodium.crypto_sign_update(state, message);
-	expect(() =>
-		sodium.crypto_sign_final_create(state, keypair.privateKey),
-	).not.toThrow();
 });
 
 test("crypto_sign_final_create rejects double-final", () => {

--- a/test/state-addresses.test.ts
+++ b/test/state-addresses.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+
+import { init } from "./test_helper.ts";
+
+const sodium = await init();
+
+test("free rejects invalid addresses", () => {
+	for (const bad of [undefined, null, NaN, 0, -1, 1.5, "foo", true]) {
+		expect(() => sodium.free(bad)).toThrow(TypeError);
+	}
+});
+
+test("crypto_sign_update rejects invalid state_address values", () => {
+	const message = sodium.from_string("hello");
+	for (const bad of [undefined, null, NaN, 0, -1, 1.5, "foo", true]) {
+		expect(() => sodium.crypto_sign_update(bad, message)).toThrow(TypeError);
+	}
+});

--- a/wrapper/macros/input_auth_hmacsha256_state_address.js
+++ b/wrapper/macros/input_auth_hmacsha256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (auth_hmacsha256_state_address)
 
-_require_address(address_pool, {var_name}, "{var_name}");
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/input_auth_hmacsha256_state_address.js
+++ b/wrapper/macros/input_auth_hmacsha256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (auth_hmacsha256_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_auth_hmacsha512256_state_address.js
+++ b/wrapper/macros/input_auth_hmacsha512256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (auth_hmacsha512256_state_address)
 
-_require_address(address_pool, {var_name}, "{var_name}");
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/input_auth_hmacsha512256_state_address.js
+++ b/wrapper/macros/input_auth_hmacsha512256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (auth_hmacsha512256_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_auth_hmacsha512_state_address.js
+++ b/wrapper/macros/input_auth_hmacsha512_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (auth_hmacsha512_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_auth_hmacsha512_state_address.js
+++ b/wrapper/macros/input_auth_hmacsha512_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (auth_hmacsha512_state_address)
 
-_require_address(address_pool, {var_name}, "{var_name}");
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/input_generichash_state_address.js
+++ b/wrapper/macros/input_generichash_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (generichash_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_generichash_state_address.js
+++ b/wrapper/macros/input_generichash_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (generichash_state_address)
 
-_require_address(address_pool, {var_name}, "{var_name}");
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/input_hash_sha256_state_address.js
+++ b/wrapper/macros/input_hash_sha256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (hash_sha256_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_hash_sha256_state_address.js
+++ b/wrapper/macros/input_hash_sha256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (hash_sha256_state_address)
 
-_require_address(address_pool, {var_name}, "{var_name}");
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/input_hash_sha3256_state_address.js
+++ b/wrapper/macros/input_hash_sha3256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (hash_sha3256_state_address)
 
-_require_address(address_pool, {var_name}, "{var_name}");
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/input_hash_sha3256_state_address.js
+++ b/wrapper/macros/input_hash_sha3256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (hash_sha3256_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_hash_sha3512_state_address.js
+++ b/wrapper/macros/input_hash_sha3512_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (hash_sha3512_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_hash_sha3512_state_address.js
+++ b/wrapper/macros/input_hash_sha3512_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (hash_sha3512_state_address)
 
-_require_address(address_pool, {var_name}, "{var_name}");
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/input_hash_sha512_state_address.js
+++ b/wrapper/macros/input_hash_sha512_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (hash_sha512_state_address)
 
-_require_address(address_pool, {var_name}, "{var_name}");
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/input_hash_sha512_state_address.js
+++ b/wrapper/macros/input_hash_sha512_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (hash_sha512_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_onetimeauth_state_address.js
+++ b/wrapper/macros/input_onetimeauth_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (onetimeauth_state_address)
 
-_require_address(address_pool, {var_name}, "{var_name}");
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/input_onetimeauth_state_address.js
+++ b/wrapper/macros/input_onetimeauth_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (onetimeauth_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_secretstream_xchacha20poly1305_state_address.js
+++ b/wrapper/macros/input_secretstream_xchacha20poly1305_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (secretstream_xchacha20poly1305_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_secretstream_xchacha20poly1305_state_address.js
+++ b/wrapper/macros/input_secretstream_xchacha20poly1305_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (secretstream_xchacha20poly1305_state_address)
 
-_require_address(address_pool, {var_name}, "{var_name}");
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/input_sign_state_address.js
+++ b/wrapper/macros/input_sign_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (sign_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_sign_state_address.js
+++ b/wrapper/macros/input_sign_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (sign_state_address)
 
-_require_address(address_pool, {var_name}, "{var_name}");
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/input_xof_shake128_state_address.js
+++ b/wrapper/macros/input_xof_shake128_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (xof_shake128_state_address)
 
-_require_address(address_pool, {var_name}, "{var_name}");
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/input_xof_shake128_state_address.js
+++ b/wrapper/macros/input_xof_shake128_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (xof_shake128_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_xof_shake256_state_address.js
+++ b/wrapper/macros/input_xof_shake256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (xof_shake256_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_xof_shake256_state_address.js
+++ b/wrapper/macros/input_xof_shake256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (xof_shake256_state_address)
 
-_require_address(address_pool, {var_name}, "{var_name}");
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/input_xof_turboshake128_state_address.js
+++ b/wrapper/macros/input_xof_turboshake128_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (xof_turboshake128_state_address)
 
-_require_address(address_pool, {var_name}, "{var_name}");
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/input_xof_turboshake128_state_address.js
+++ b/wrapper/macros/input_xof_turboshake128_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (xof_turboshake128_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_xof_turboshake256_state_address.js
+++ b/wrapper/macros/input_xof_turboshake256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (xof_turboshake256_state_address)
 
-_require_defined(address_pool, {var_name}, "{var_name}");
+_require_address(address_pool, {var_name}, "{var_name}");

--- a/wrapper/macros/input_xof_turboshake256_state_address.js
+++ b/wrapper/macros/input_xof_turboshake256_state_address.js
@@ -1,3 +1,3 @@
 // ---------- input: {var_name} (xof_turboshake256_state_address)
 
-_require_address(address_pool, {var_name}, "{var_name}");
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/output_auth_hmacsha256_state.js
+++ b/wrapper/macros/output_auth_hmacsha256_state.js
@@ -1,3 +1,3 @@
 // ---------- output {var_name} (auth_hmacsha256_state)
 
-var {var_name}_address = new AllocatedBuf(208).address;
+var {var_name}_address = _malloc_state_address(208);

--- a/wrapper/macros/output_auth_hmacsha512256_state.js
+++ b/wrapper/macros/output_auth_hmacsha512256_state.js
@@ -1,3 +1,3 @@
 // ---------- output {var_name} (auth_hmacsha512256_state)
 
-var {var_name}_address = new AllocatedBuf(416).address;
+var {var_name}_address = _malloc_state_address(416);

--- a/wrapper/macros/output_auth_hmacsha512_state.js
+++ b/wrapper/macros/output_auth_hmacsha512_state.js
@@ -1,3 +1,3 @@
 // ---------- output {var_name} (auth_hmacsha512_state)
 
-var {var_name}_address = new AllocatedBuf(416).address;
+var {var_name}_address = _malloc_state_address(416);

--- a/wrapper/macros/output_generichash_state.js
+++ b/wrapper/macros/output_generichash_state.js
@@ -1,3 +1,3 @@
 // ---------- output {var_name} (generichash_state)
 
-var {var_name}_address = new AllocatedBuf(libsodium._crypto_generichash_statebytes()).address;
+var {var_name}_address = _malloc_state_address(libsodium._crypto_generichash_statebytes());

--- a/wrapper/macros/output_hash_sha256_state.js
+++ b/wrapper/macros/output_hash_sha256_state.js
@@ -1,3 +1,3 @@
 // ---------- output {var_name} (hash_sha256_state)
 
-var {var_name}_address = new AllocatedBuf(104).address;
+var {var_name}_address = _malloc_state_address(104);

--- a/wrapper/macros/output_hash_sha3256_state.js
+++ b/wrapper/macros/output_hash_sha3256_state.js
@@ -1,3 +1,3 @@
 // ---------- output {var_name} (hash_sha3256_state)
 
-var {var_name}_address = new AllocatedBuf(256).address;
+var {var_name}_address = _malloc_state_address(256);

--- a/wrapper/macros/output_hash_sha3512_state.js
+++ b/wrapper/macros/output_hash_sha3512_state.js
@@ -1,3 +1,3 @@
 // ---------- output {var_name} (hash_sha3512_state)
 
-var {var_name}_address = new AllocatedBuf(256).address;
+var {var_name}_address = _malloc_state_address(256);

--- a/wrapper/macros/output_hash_sha512_state.js
+++ b/wrapper/macros/output_hash_sha512_state.js
@@ -1,3 +1,3 @@
 // ---------- output {var_name} (hash_sha512_state)
 
-var {var_name}_address = new AllocatedBuf(208).address;
+var {var_name}_address = _malloc_state_address(208);

--- a/wrapper/macros/output_onetimeauth_state.js
+++ b/wrapper/macros/output_onetimeauth_state.js
@@ -1,3 +1,3 @@
 // ---------- output {var_name} (onetimeauth_state)
 
-var {var_name}_address = new AllocatedBuf(144).address;
+var {var_name}_address = _malloc_state_address(144);

--- a/wrapper/macros/output_secretstream_xchacha20poly1305_state.js
+++ b/wrapper/macros/output_secretstream_xchacha20poly1305_state.js
@@ -1,3 +1,3 @@
 // ---------- output {var_name} (secretstream_xchacha20poly1305_state)
 
-var {var_name}_address = new AllocatedBuf(52).address;
+var {var_name}_address = _malloc_state_address(52);

--- a/wrapper/macros/output_sign_state.js
+++ b/wrapper/macros/output_sign_state.js
@@ -1,3 +1,3 @@
 // ---------- output {var_name} (sign_state)
 
-var {var_name}_address = new AllocatedBuf(208).address;
+var {var_name}_address = _malloc_state_address(208);

--- a/wrapper/macros/output_xof_shake128_state.js
+++ b/wrapper/macros/output_xof_shake128_state.js
@@ -1,3 +1,3 @@
 // ---------- output {var_name} (xof_shake128_state)
 
-var {var_name}_address = new AllocatedBuf(256).address;
+var {var_name}_address = _malloc_state_address(256);

--- a/wrapper/macros/output_xof_shake256_state.js
+++ b/wrapper/macros/output_xof_shake256_state.js
@@ -1,3 +1,3 @@
 // ---------- output {var_name} (xof_shake256_state)
 
-var {var_name}_address = new AllocatedBuf(256).address;
+var {var_name}_address = _malloc_state_address(256);

--- a/wrapper/macros/output_xof_turboshake128_state.js
+++ b/wrapper/macros/output_xof_turboshake128_state.js
@@ -1,3 +1,3 @@
 // ---------- output {var_name} (xof_turboshake128_state)
 
-var {var_name}_address = new AllocatedBuf(256).address;
+var {var_name}_address = _malloc_state_address(256);

--- a/wrapper/macros/output_xof_turboshake256_state.js
+++ b/wrapper/macros/output_xof_turboshake256_state.js
@@ -1,3 +1,3 @@
 // ---------- output {var_name} (xof_turboshake256_state)
 
-var {var_name}_address = new AllocatedBuf(256).address;
+var {var_name}_address = _malloc_state_address(256);

--- a/wrapper/symbols/crypto_auth_hmacsha256_final.json
+++ b/wrapper/symbols/crypto_auth_hmacsha256_final.json
@@ -21,5 +21,5 @@
       "or_else_throw": "invalid usage"
     }
   ],
-  "return": "(libsodium._free(state_address), _format_output(hash, outputFormat))"
+  "return": "(_free_state_address(state_address), _format_output(hash, outputFormat))"
 }

--- a/wrapper/symbols/crypto_auth_hmacsha512256_final.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512256_final.json
@@ -21,5 +21,5 @@
       "or_else_throw": "invalid usage"
     }
   ],
-  "return": "(libsodium._free(state_address), _format_output(hash, outputFormat))"
+  "return": "(_free_state_address(state_address), _format_output(hash, outputFormat))"
 }

--- a/wrapper/symbols/crypto_auth_hmacsha512_final.json
+++ b/wrapper/symbols/crypto_auth_hmacsha512_final.json
@@ -21,5 +21,5 @@
       "or_else_throw": "invalid usage"
     }
   ],
-  "return": "(libsodium._free(state_address), _format_output(hash, outputFormat))"
+  "return": "(_free_state_address(state_address), _format_output(hash, outputFormat))"
 }

--- a/wrapper/symbols/crypto_generichash_final.json
+++ b/wrapper/symbols/crypto_generichash_final.json
@@ -27,5 +27,5 @@
       "or_else_throw": "invalid usage"
     }
   ],
-  "return": "(libsodium._free(state_address), _format_output(hash, outputFormat))"
+  "return": "(_free_state_address(state_address), _format_output(hash, outputFormat))"
 }

--- a/wrapper/symbols/crypto_hash_sha256_final.json
+++ b/wrapper/symbols/crypto_hash_sha256_final.json
@@ -21,5 +21,5 @@
       "or_else_throw": "invalid usage"
     }
   ],
-  "return": "(libsodium._free(state_address), _format_output(hash, outputFormat))"
+  "return": "(_free_state_address(state_address), _format_output(hash, outputFormat))"
 }

--- a/wrapper/symbols/crypto_hash_sha3256_final.json
+++ b/wrapper/symbols/crypto_hash_sha3256_final.json
@@ -21,5 +21,5 @@
       "or_else_throw": "invalid usage"
     }
   ],
-  "return": "(libsodium._free(state_address), _format_output(hash, outputFormat))"
+  "return": "(_free_state_address(state_address), _format_output(hash, outputFormat))"
 }

--- a/wrapper/symbols/crypto_hash_sha3512_final.json
+++ b/wrapper/symbols/crypto_hash_sha3512_final.json
@@ -21,5 +21,5 @@
       "or_else_throw": "invalid usage"
     }
   ],
-  "return": "(libsodium._free(state_address), _format_output(hash, outputFormat))"
+  "return": "(_free_state_address(state_address), _format_output(hash, outputFormat))"
 }

--- a/wrapper/symbols/crypto_hash_sha512_final.json
+++ b/wrapper/symbols/crypto_hash_sha512_final.json
@@ -21,5 +21,5 @@
       "or_else_throw": "invalid usage"
     }
   ],
-  "return": "(libsodium._free(state_address), _format_output(hash, outputFormat))"
+  "return": "(_free_state_address(state_address), _format_output(hash, outputFormat))"
 }

--- a/wrapper/symbols/crypto_onetimeauth_final.json
+++ b/wrapper/symbols/crypto_onetimeauth_final.json
@@ -21,5 +21,5 @@
       "or_else_throw": "invalid usage"
     }
   ],
-  "return": "(libsodium._free(state_address), _format_output(hash, outputFormat))"
+  "return": "(_free_state_address(state_address), _format_output(hash, outputFormat))"
 }

--- a/wrapper/symbols/crypto_sign_final_create.json
+++ b/wrapper/symbols/crypto_sign_final_create.json
@@ -26,5 +26,5 @@
       "or_else_throw": "invalid usage"
     }
   ],
-  "return": "(libsodium._free(state_address), _format_output(signature, outputFormat))"
+  "return": "(_free_state_address(state_address), _format_output(signature, outputFormat))"
 }

--- a/wrapper/symbols/crypto_sign_final_verify.json
+++ b/wrapper/symbols/crypto_sign_final_verify.json
@@ -19,5 +19,5 @@
   ],
   "outputs": [],
   "target": "var verificationResult = libsodium._crypto_sign_final_verify(state_address, signature_address, publicKey_address) | 0",
-  "return": "(libsodium._free(state_address), verificationResult === 0)"
+  "return": "(_free_state_address(state_address), verificationResult === 0)"
 }

--- a/wrapper/wrap-esm-template.js
+++ b/wrapper/wrap-esm-template.js
@@ -78,13 +78,7 @@ function symbols() {
 }
 
 function free(state_address) {
-  if (
-    typeof state_address !== "number" ||
-    !isFinite(state_address) ||
-    state_address <= 0
-  ) {
-    throw new TypeError("state_address must be a valid StateAddress");
-  }
+  _require_address(null, state_address, "state_address");
   _free(state_address);
 }
 
@@ -581,6 +575,20 @@ function _require_defined(address_pool, varValue, varName) {
     _free_and_throw_type_error(
       address_pool,
       varName + " cannot be null or undefined"
+    );
+  }
+}
+
+function _require_address(address_pool, varValue, varName) {
+  _require_defined(address_pool, varValue, varName);
+  if (
+    typeof varValue !== "number" ||
+    !Number.isInteger(varValue) ||
+    varValue <= 0 || varValue > 0xffffffff
+  ) {
+    _free_and_throw_type_error(
+      address_pool,
+      varName + " is not a valid address"
     );
   }
 }

--- a/wrapper/wrap-esm-template.js
+++ b/wrapper/wrap-esm-template.js
@@ -78,8 +78,8 @@ function symbols() {
 }
 
 function free(state_address) {
-  _require_address(null, state_address, "state_address");
-  _free(state_address);
+  _require_state_address(null, state_address);
+  _free_state_address(state_address);
 }
 
 function increment(bytes) {
@@ -548,14 +548,23 @@ function _malloc(length) {
   return result;
 }
 
-function _free(address) {
+var _state_addresses = new Set();
+
+function _malloc_state_address(size) {
+  var address = _malloc(size);
+  _state_addresses.add(address);
+  return address;
+}
+
+function _free_state_address(address) {
+  _state_addresses.delete(address);
   libsodium._free(address);
 }
 
 function _free_all(addresses) {
   if (addresses) {
     for (var i = 0; i < addresses.length; i++) {
-      _free(addresses[i]);
+      libsodium._free(addresses[i]);
     }
   }
 }
@@ -590,6 +599,13 @@ function _require_address(address_pool, varValue, varName) {
       address_pool,
       varName + " is not a valid address"
     );
+  }
+}
+
+function _require_state_address(address_pool, address) {
+  _require_address(address_pool, address, "state_address");
+  if (!_state_addresses.has(address)) {
+    _free_and_throw_error(address_pool, "state_address is unknown");
   }
 }
 

--- a/wrapper/wrap-template.js
+++ b/wrapper/wrap-template.js
@@ -47,13 +47,7 @@
     }
 
     function free(state_address) {
-      if (
-        typeof state_address !== "number" ||
-        !isFinite(state_address) ||
-        state_address <= 0
-      ) {
-        throw new TypeError("state_address must be a valid StateAddress");
-      }
+      _require_address(null, state_address, "state_address");
       _free(state_address);
     }
 
@@ -571,6 +565,20 @@
         _free_and_throw_type_error(
           address_pool,
           varName + " cannot be null or undefined"
+        );
+      }
+    }
+
+    function _require_address(address_pool, varValue, varName) {
+      _require_defined(address_pool, varValue, varName);
+      if (
+        typeof varValue !== "number" ||
+        !Number.isInteger(varValue) ||
+        varValue <= 0 || varValue > 0xffffffff
+      ) {
+        _free_and_throw_type_error(
+          address_pool,
+          varName + " is not a valid address"
         );
       }
     }

--- a/wrapper/wrap-template.js
+++ b/wrapper/wrap-template.js
@@ -47,8 +47,8 @@
     }
 
     function free(state_address) {
-      _require_address(null, state_address, "state_address");
-      _free(state_address);
+      _require_state_address(null, state_address);
+      _free_state_address(state_address);
     }
 
     function increment(bytes) {
@@ -538,14 +538,23 @@
       return result;
     }
 
-    function _free(address) {
+    var _state_addresses = new Set();
+
+    function _malloc_state_address(size) {
+      var address = _malloc(size);
+      _state_addresses.add(address);
+      return address;
+    }
+
+    function _free_state_address(address) {
+      _state_addresses.delete(address);
       libsodium._free(address);
     }
 
     function _free_all(addresses) {
       if (addresses) {
         for (var i = 0; i < addresses.length; i++) {
-          _free(addresses[i]);
+          libsodium._free(addresses[i]);
         }
       }
     }
@@ -580,6 +589,13 @@
           address_pool,
           varName + " is not a valid address"
         );
+      }
+    }
+
+    function _require_state_address(address_pool, address) {
+      _require_address(address_pool, address, "state_address");
+      if (!_state_addresses.has(address)) {
+        _free_and_throw_error(address_pool, "state_address is unknown");
       }
     }
 


### PR DESCRIPTION
Stacks on PR #383 to make state_address operations detect liveness validity in addition to #383 value validity checks  

### What changes

This PR adds a small amount of overhead with Set() state and operations to track state_address liveness, which aligns better with the memory safety assumptions of most JS code. Without these changes, errant calls to `free()` or `*_final` or `*_update` cause silent corruption, which is typical with C but not with JS.

### Newly caught errors
 - free (or *_final) of untracked addresses
 - double free (or *_final)
 - use (or *_update) after free (or *_final)