### PR TITLE
zero WASM heap allocations from JS before free

### DIFF
--- a/test/memzero.test.ts
+++ b/test/memzero.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+
+import { init } from "./test_helper.ts";
+
+const sodium = await init();
+
+// Monkey patch to verify freed memory is zeroed
+const sizes = new Map<number, number>();
+let origMalloc: (size: number) => number;
+let origFree: (addr: number) => void;
+
+beforeEach(() => {
+	sizes.clear();
+	origMalloc = sodium.libsodium._malloc;
+	origFree = sodium.libsodium._free;
+	sodium.libsodium._malloc = (size: number) => {
+		const addr = origMalloc(size);
+		sizes.set(addr, size);
+		return addr;
+	};
+	sodium.libsodium._free = (addr: number) => {
+		const size = sizes.get(addr);
+		if (size != null) {
+			const region = sodium.libsodium.HEAPU8.subarray(addr, addr + size);
+			expect(region.every((b: number) => b === 0)).toBe(true);
+			sizes.delete(addr);
+		}
+		origFree(addr);
+	};
+});
+
+afterEach(() => {
+	sodium.libsodium._malloc = origMalloc;
+	sodium.libsodium._free = origFree;
+});
+
+test("crypto_secretbox_easy buffers get zeroed", () => {
+	const key = sodium.randombytes_buf(sodium.crypto_secretbox_KEYBYTES);
+	const nonce = sodium.randombytes_buf(sodium.crypto_secretbox_NONCEBYTES);
+	sodium.crypto_secretbox_easy(sodium.from_string("hello"), nonce, key);
+});
+
+test("crypto_kem_enc buffers get zeroed", () => {
+	const keypair = sodium.crypto_kem_keypair();
+	sodium.crypto_kem_enc(keypair.publicKey);
+});
+
+test("sodium.pad buffers get zeroed", () => {
+	sodium.pad(sodium.from_string("plaintext"), 16);
+});

--- a/test/state-addresses.test.ts
+++ b/test/state-addresses.test.ts
@@ -1,8 +1,38 @@
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, test } from "bun:test";
 
 import { init } from "./test_helper.ts";
 
 const sodium = await init();
+
+// Monkey patch to verify freed memory is zeroed
+const sizes = new Map<number, number>();
+let origMalloc: (size: number) => number;
+let origFree: (addr: number) => void;
+
+beforeEach(() => {
+	sizes.clear();
+	origMalloc = sodium.libsodium._malloc;
+	origFree = sodium.libsodium._free;
+	sodium.libsodium._malloc = (size: number) => {
+		const addr = origMalloc(size);
+		sizes.set(addr, size);
+		return addr;
+	};
+	sodium.libsodium._free = (addr: number) => {
+		const size = sizes.get(addr);
+		if (size != null) {
+			const region = sodium.libsodium.HEAPU8.subarray(addr, addr + size);
+			expect(region.every((b: number) => b === 0)).toBe(true);
+			sizes.delete(addr);
+		}
+		origFree(addr);
+	};
+});
+
+afterEach(() => {
+	sodium.libsodium._malloc = origMalloc;
+	sodium.libsodium._free = origFree;
+});
 
 test("free rejects invalid addresses", () => {
 	for (const bad of [undefined, null, NaN, 0, -1, 1.5, "foo", true]) {
@@ -21,6 +51,7 @@ test("crypto_xof_shake128_update rejects invalid addresses", () => {
 
 test("free accepts valid state", () => {
 	const state = sodium.crypto_xof_shake128_init();
+	sodium.crypto_xof_shake128_update(state, sodium.from_string("data"));
 	expect(() => sodium.free(state)).not.toThrow();
 });
 
@@ -33,6 +64,8 @@ test("free rejects double-free", () => {
 test("free rejects untracked state", () => {
 	const garbage = sodium.libsodium._malloc(256);
 	expect(() => sodium.free(garbage)).toThrow(Error);
+	// Manually zero because `garbage` is untracked
+	sodium.libsodium.HEAPU8.fill(0, garbage, garbage + 256);
 	sodium.libsodium._free(garbage);
 });
 
@@ -52,6 +85,8 @@ test("crypto_xof_shake128_update rejects untracked state", () => {
 	expect(() => sodium.crypto_xof_shake128_update(garbage, message)).toThrow(
 		Error,
 	);
+	// Manually zero because `garbage` is untracked
+	sodium.libsodium.HEAPU8.fill(0, garbage, garbage + 256);
 	sodium.libsodium._free(garbage);
 });
 

--- a/wrapper/build-wrappers.ts
+++ b/wrapper/build-wrappers.ts
@@ -163,7 +163,7 @@ class WrapperBuilder {
 			if (symbol.return !== undefined) {
 				lines.push(`if ((${target}) ${assert.condition}) {`);
 				lines.push(`\tvar ret = ${symbol.return};`);
-				lines.push("\t_free_all(address_pool);");
+				lines.push("\t_free_pool(address_pool);");
 				lines.push("\treturn ret;");
 				lines.push("}");
 				lines.push(
@@ -175,12 +175,12 @@ class WrapperBuilder {
 					`\t_free_and_throw_error(address_pool, "${assert.or_else_throw}");`,
 				);
 				lines.push("}");
-				lines.push("_free_all(address_pool);");
+				lines.push("_free_pool(address_pool);");
 			}
 		} else if (symbol.return !== undefined) {
 			lines.push(this.ensureSemicolon(symbol.target!));
 			lines.push(`var ret = (${symbol.return});`);
-			lines.push("_free_all(address_pool);");
+			lines.push("_free_pool(address_pool);");
 			lines.push("return ret;");
 		} else {
 			lines.push(this.ensureSemicolon(symbol.target!));

--- a/wrapper/macros/input_buf.js
+++ b/wrapper/macros/input_buf.js
@@ -5,5 +5,4 @@ var {var_name}_address, {var_name}_length = ({var_length}) | 0;
 if ({var_name}.length !== {var_name}_length) {
     _free_and_throw_type_error(address_pool, "invalid {var_name} length");
 }
-{var_name}_address = _to_allocated_buf_address({var_name});
-address_pool.push({var_name}_address);
+{var_name}_address = _to_allocated_buf_address(address_pool, {var_name});

--- a/wrapper/macros/input_buf_optional.js
+++ b/wrapper/macros/input_buf_optional.js
@@ -7,6 +7,5 @@ if ({var_name} != undefined) {
         if ({var_name}.length !== {var_name}_length) {
             _free_and_throw_type_error(address_pool, "invalid {var_name} length");
         }
-        {var_name}_address = _to_allocated_buf_address({var_name});
-        address_pool.push({var_name}_address);
+        {var_name}_address = _to_allocated_buf_address(address_pool, {var_name});
 }

--- a/wrapper/macros/input_minsized_buf.js
+++ b/wrapper/macros/input_minsized_buf.js
@@ -5,5 +5,4 @@ var {var_name}_address, {var_name}_min_length = {var_min_length}, {var_name}_len
 if ({var_name}_length < {var_name}_min_length) {
         _free_and_throw_type_error(address_pool, "{var_name} is too short");
 }
-{var_name}_address = _to_allocated_buf_address({var_name});
-address_pool.push({var_name}_address);
+{var_name}_address = _to_allocated_buf_address(address_pool, {var_name});

--- a/wrapper/macros/input_string.js
+++ b/wrapper/macros/input_string.js
@@ -7,6 +7,5 @@ if (typeof {var_name} !== "string") {
 if ({var_name}.length - 1 !== {var_length}) {
     _free_and_throw_type_error(address_pool, "invalid {var_name} length");
 }
-var {var_name}_address = _to_allocated_buf_address({var_name}),
+var {var_name}_address = _to_allocated_buf_address(address_pool, {var_name}),
     {var_name}_length = {var_name}.length - 1;
-address_pool.push({var_name}_address);

--- a/wrapper/macros/input_unsized_buf.js
+++ b/wrapper/macros/input_unsized_buf.js
@@ -1,6 +1,5 @@
 // ---------- input: {var_name} (unsized_buf)
 
 {var_name} = _any_to_Uint8Array(address_pool, {var_name}, "{var_name}");
-var {var_name}_address = _to_allocated_buf_address({var_name}),
+var {var_name}_address = _to_allocated_buf_address(address_pool, {var_name}),
     {var_name}_length = {var_name}.length;
-address_pool.push({var_name}_address);

--- a/wrapper/macros/input_unsized_buf_optional.js
+++ b/wrapper/macros/input_unsized_buf_optional.js
@@ -3,7 +3,6 @@
 var {var_name}_address = null, {var_name}_length = 0;
 if ({var_name} != undefined) {
         {var_name} = _any_to_Uint8Array(address_pool, {var_name}, "{var_name}");
-        {var_name}_address = _to_allocated_buf_address({var_name});
+        {var_name}_address = _to_allocated_buf_address(address_pool, {var_name});
         {var_name}_length = {var_name}.length;
-        address_pool.push({var_name}_address);
 }

--- a/wrapper/macros/input_unsized_string.js
+++ b/wrapper/macros/input_unsized_string.js
@@ -4,6 +4,5 @@ if (typeof {var_name} !== "string") {
     _free_and_throw_type_error(address_pool, "{var_name} must be a string");
 }
 {var_name} = from_string({var_name} + "\0");
-var {var_name}_address = _to_allocated_buf_address({var_name}),
+var {var_name}_address = _to_allocated_buf_address(address_pool, {var_name}),
     {var_name}_length = {var_name}.length - 1;
-address_pool.push({var_name}_address);

--- a/wrapper/macros/output_buf.js
+++ b/wrapper/macros/output_buf.js
@@ -1,7 +1,5 @@
 // ---------- output {var_name} (buf)
 
 var {var_name}_length = ({var_length}) | 0,
-    {var_name} = new AllocatedBuf({var_name}_length),
+    {var_name} = _malloc_pool_buf(address_pool, {var_name}_length),
     {var_name}_address = {var_name}.address;
-
-address_pool.push({var_name}_address);

--- a/wrapper/symbols/crypto_secretstream_xchacha20poly1305_pull.json
+++ b/wrapper/symbols/crypto_secretstream_xchacha20poly1305_pull.json
@@ -23,6 +23,6 @@
       "length": "cipher_length - libsodium._crypto_secretstream_xchacha20poly1305_abytes()"
     }
   ],
-  "target": "var ret = (function() { var tag_p = _malloc(1); address_pool.push(tag_p); return libsodium._crypto_secretstream_xchacha20poly1305_pull(state_address, message_chunk_address, 0, tag_p, cipher_address, cipher_length, 0, ad_address, ad_length) === 0 && { tag: libsodium.HEAPU8[tag_p], message: message_chunk } } )()",
+  "target": "var ret = (function() { var tag_p = _malloc_pool_buf(address_pool, 1).address; return libsodium._crypto_secretstream_xchacha20poly1305_pull(state_address, message_chunk_address, 0, tag_p, cipher_address, cipher_length, 0, ad_address, ad_length) === 0 && { tag: libsodium.HEAPU8[tag_p], message: message_chunk } } )()",
   "return": "ret && {message: _format_output(ret.message, outputFormat), tag: ret.tag}"
 }

--- a/wrapper/wrap-esm-template.js
+++ b/wrapper/wrap-esm-template.js
@@ -172,13 +172,11 @@ function pad(buf, blocksize) {
   }
   var address_pool = [],
     padded,
-    padded_buflen_p = _malloc(4),
+    padded_buflen_p = _malloc_pool_buf(address_pool, 4).address,
     st = 1 | 0,
     i = 0 | 0,
     k = buf.length | 0,
-    bufx = new AllocatedBuf(k + blocksize);
-  address_pool.push(padded_buflen_p);
-  address_pool.push(bufx.address);
+    bufx = _malloc_pool_buf(address_pool, k + blocksize);
   for (
     var j = bufx.address, jmax = bufx.address + k + blocksize; j < jmax; j++
   ) {
@@ -199,9 +197,8 @@ function pad(buf, blocksize) {
   ) {
     _free_and_throw_error(address_pool, "internal error");
   }
-  bufx.length = libsodium.getValue(padded_buflen_p, "i32");
-  padded = bufx.to_Uint8Array();
-  _free_all(address_pool);
+  padded = bufx.to_Uint8Array(libsodium.getValue(padded_buflen_p, "i32"));
+  _free_pool(address_pool);
   return padded;
 }
 
@@ -214,10 +211,8 @@ function unpad(buf, blocksize) {
     throw new Error("block size must be > 0");
   }
   var address_pool = [],
-    unpadded_address = _to_allocated_buf_address(buf),
-    unpadded_buflen_p = _malloc(4);
-  address_pool.push(unpadded_address);
-  address_pool.push(unpadded_buflen_p);
+    unpadded_address = _to_allocated_buf_address(address_pool, buf),
+    unpadded_buflen_p = _malloc_pool_buf(address_pool, 4).address;
   if (
     libsodium._sodium_unpad(
       unpadded_buflen_p,
@@ -230,7 +225,7 @@ function unpad(buf, blocksize) {
   }
   buf = new Uint8Array(buf);
   buf = buf.subarray(0, libsodium.getValue(unpadded_buflen_p, "i32"));
-  _free_all(address_pool);
+  _free_pool(address_pool);
   return buf;
 }
 
@@ -313,14 +308,11 @@ function to_string(bytes) {
 function from_hex(input) {
   var address_pool = [],
     input = _any_to_Uint8Array(address_pool, input, "input"),
-    result = new AllocatedBuf(input.length / 2),
+    result = _malloc_pool_buf(address_pool, input.length / 2),
     result_str,
-    input_address = _to_allocated_buf_address(input),
-    hex_end_p = _malloc(4),
+    input_address = _to_allocated_buf_address(address_pool, input),
+    hex_end_p = _malloc_pool_buf(address_pool, 4).address,
     hex_end;
-  address_pool.push(input_address);
-  address_pool.push(result.address);
-  address_pool.push(hex_end_p);
   if (
     libsodium._sodium_hex2bin(
       result.address,
@@ -339,7 +331,7 @@ function from_hex(input) {
     _free_and_throw_error(address_pool, "incomplete input");
   }
   result_str = result.to_Uint8Array();
-  _free_all(address_pool);
+  _free_pool(address_pool);
   return result_str;
 }
 
@@ -386,16 +378,12 @@ function from_base64(input, variant) {
   variant = check_base64_variant(variant);
   var address_pool = [],
     input = _any_to_Uint8Array(address_pool, input, "input"),
-    result = new AllocatedBuf(input.length * 3 / 4),
+    result = _malloc_pool_buf(address_pool, input.length * 3 / 4),
     result_bin,
-    input_address = _to_allocated_buf_address(input),
-    result_bin_len_p = _malloc(4),
-    b64_end_p = _malloc(4),
+    input_address = _to_allocated_buf_address(address_pool, input),
+    result_bin_len_p = _malloc_pool_buf(address_pool, 4).address,
+    b64_end_p = _malloc_pool_buf(address_pool, 4).address,
     b64_end;
-  address_pool.push(input_address);
-  address_pool.push(result.address);
-  address_pool.push(result_bin_len_p);
-  address_pool.push(b64_end_p);
   if (
     libsodium._sodium_base642bin(
       result.address,
@@ -414,9 +402,8 @@ function from_base64(input, variant) {
   if (b64_end - input_address !== input.length) {
     _free_and_throw_error(address_pool, "incomplete input");
   }
-  result.length = libsodium.getValue(result_bin_len_p, "i32");
-  result_bin = result.to_Uint8Array();
-  _free_all(address_pool);
+  result_bin = result.to_Uint8Array(libsodium.getValue(result_bin_len_p, "i32"));
+  _free_pool(address_pool);
   return result_bin;
 }
 
@@ -431,11 +418,9 @@ function to_base64(input, variant) {
     (remainder !== 0 ?
       (variant & 2) === 0 ? 4 : 2 + (remainder >>> 1) :
       0),
-    result = new AllocatedBuf(b64_len + 1),
+    result = _malloc_pool_buf(address_pool, b64_len + 1),
     result_b64,
-    input_address = _to_allocated_buf_address(input);
-  address_pool.push(input_address);
-  address_pool.push(result.address);
+    input_address = _to_allocated_buf_address(address_pool, input);
   if (
     libsodium._sodium_bin2base64(
       result.address,
@@ -447,9 +432,8 @@ function to_base64(input, variant) {
   ) {
     _free_and_throw_error(address_pool, "conversion failed");
   }
-  result.length = b64_len;
-  result_b64 = to_string(result.to_Uint8Array());
-  _free_all(address_pool);
+  result_b64 = to_string(result.to_Uint8Array(b64_len));
+  _free_pool(address_pool);
   return result_b64;
 }
 
@@ -523,18 +507,24 @@ function AllocatedBuf(length) {
   this.address = _malloc(length);
 }
 
-AllocatedBuf.prototype.to_Uint8Array = function () {
-  var result = new Uint8Array(this.length);
-  result.set(
-    libsodium.HEAPU8.subarray(this.address, this.address + this.length)
-  );
+// Copy the content of a AllocatedBuf (_malloc()'d memory) into a Uint8Array
+AllocatedBuf.prototype.to_Uint8Array = function (length) {
+  var n = length === undefined ? this.length : length;
+  var result = new Uint8Array(n);
+  result.set(libsodium.HEAPU8.subarray(this.address, this.address + n));
   return result;
 };
 
-function _to_allocated_buf_address(bytes) {
-  var address = _malloc(bytes.length);
-  libsodium.HEAPU8.set(bytes, address);
-  return address;
+function _malloc_pool_buf(pool, size) {
+  var buf = new AllocatedBuf(size);
+  pool.push(buf);
+  return buf;
+}
+
+function _to_allocated_buf_address(pool, bytes) {
+  var buf = _malloc_pool_buf(pool, bytes.length);
+  libsodium.HEAPU8.set(bytes, buf.address);
+  return buf.address;
 }
 
 function _malloc(length) {
@@ -548,34 +538,40 @@ function _malloc(length) {
   return result;
 }
 
-var _state_addresses = new Set();
+var _state_addresses = new Map();
 
 function _malloc_state_address(size) {
-  var address = _malloc(size);
-  _state_addresses.add(address);
-  return address;
+  var buf = new AllocatedBuf(size);
+  _state_addresses.set(buf.address, buf);
+  return buf.address;
 }
 
 function _free_state_address(address) {
-  _state_addresses.delete(address);
+  var buf = _state_addresses.get(address);
+  if (buf !== undefined) {
+    libsodium.HEAPU8.fill(0, buf.address, buf.address + buf.length);
+    _state_addresses.delete(address);
+  }
   libsodium._free(address);
 }
 
-function _free_all(addresses) {
-  if (addresses) {
-    for (var i = 0; i < addresses.length; i++) {
-      libsodium._free(addresses[i]);
+function _free_pool(pool) {
+  if (pool) {
+    for (var i = 0; i < pool.length; i++) {
+      var buf = pool[i];
+      libsodium.HEAPU8.fill(0, buf.address, buf.address + buf.length);
+      libsodium._free(buf.address);
     }
   }
 }
 
 function _free_and_throw_error(address_pool, err) {
-  _free_all(address_pool);
+  _free_pool(address_pool);
   throw new Error(err);
 }
 
 function _free_and_throw_type_error(address_pool, err) {
-  _free_all(address_pool);
+  _free_pool(address_pool);
   throw new TypeError(err);
 }
 

--- a/wrapper/wrap-template.js
+++ b/wrapper/wrap-template.js
@@ -141,13 +141,11 @@
       }
       var address_pool = [],
         padded,
-        padded_buflen_p = _malloc(4),
+        padded_buflen_p = _malloc_pool_buf(address_pool, 4).address,
         st = 1 | 0,
         i = 0 | 0,
         k = buf.length | 0,
-        bufx = new AllocatedBuf(k + blocksize);
-      address_pool.push(padded_buflen_p);
-      address_pool.push(bufx.address);
+        bufx = _malloc_pool_buf(address_pool, k + blocksize);
       for (
         var j = bufx.address, jmax = bufx.address + k + blocksize; j < jmax; j++
       ) {
@@ -168,9 +166,8 @@
       ) {
         _free_and_throw_error(address_pool, "internal error");
       }
-      bufx.length = libsodium.getValue(padded_buflen_p, "i32");
-      padded = bufx.to_Uint8Array();
-      _free_all(address_pool);
+      padded = bufx.to_Uint8Array(libsodium.getValue(padded_buflen_p, "i32"));
+      _free_pool(address_pool);
       return padded;
     }
 
@@ -183,10 +180,8 @@
         throw new Error("block size must be > 0");
       }
       var address_pool = [],
-        unpadded_address = _to_allocated_buf_address(buf),
-        unpadded_buflen_p = _malloc(4);
-      address_pool.push(unpadded_address);
-      address_pool.push(unpadded_buflen_p);
+        unpadded_address = _to_allocated_buf_address(address_pool, buf),
+        unpadded_buflen_p = _malloc_pool_buf(address_pool, 4).address;
       if (
         libsodium._sodium_unpad(
           unpadded_buflen_p,
@@ -199,7 +194,7 @@
       }
       buf = new Uint8Array(buf);
       buf = buf.subarray(0, libsodium.getValue(unpadded_buflen_p, "i32"));
-      _free_all(address_pool);
+      _free_pool(address_pool);
       return buf;
     }
 
@@ -296,14 +291,11 @@
     function from_hex(input) {
       var address_pool = [],
         input = _any_to_Uint8Array(address_pool, input, "input"),
-        result = new AllocatedBuf(input.length / 2),
+        result = _malloc_pool_buf(address_pool, input.length / 2),
         result_str,
-        input_address = _to_allocated_buf_address(input),
-        hex_end_p = _malloc(4),
+        input_address = _to_allocated_buf_address(address_pool, input),
+        hex_end_p = _malloc_pool_buf(address_pool, 4).address,
         hex_end;
-      address_pool.push(input_address);
-      address_pool.push(result.address);
-      address_pool.push(hex_end_p);
       if (
         libsodium._sodium_hex2bin(
           result.address,
@@ -322,7 +314,7 @@
         _free_and_throw_error(address_pool, "incomplete input");
       }
       result_str = result.to_Uint8Array();
-      _free_all(address_pool);
+      _free_pool(address_pool);
       return result_str;
     }
 
@@ -369,16 +361,12 @@
       variant = check_base64_variant(variant);
       var address_pool = [],
         input = _any_to_Uint8Array(address_pool, input, "input"),
-        result = new AllocatedBuf(input.length * 3 / 4),
+        result = _malloc_pool_buf(address_pool, input.length * 3 / 4),
         result_bin,
-        input_address = _to_allocated_buf_address(input),
-        result_bin_len_p = _malloc(4),
-        b64_end_p = _malloc(4),
+        input_address = _to_allocated_buf_address(address_pool, input),
+        result_bin_len_p = _malloc_pool_buf(address_pool, 4).address,
+        b64_end_p = _malloc_pool_buf(address_pool, 4).address,
         b64_end;
-      address_pool.push(input_address);
-      address_pool.push(result.address);
-      address_pool.push(result_bin_len_p);
-      address_pool.push(b64_end_p);
       if (
         libsodium._sodium_base642bin(
           result.address,
@@ -397,9 +385,8 @@
       if (b64_end - input_address !== input.length) {
         _free_and_throw_error(address_pool, "incomplete input");
       }
-      result.length = libsodium.getValue(result_bin_len_p, "i32");
-      result_bin = result.to_Uint8Array();
-      _free_all(address_pool);
+      result_bin = result.to_Uint8Array(libsodium.getValue(result_bin_len_p, "i32"));
+      _free_pool(address_pool);
       return result_bin;
     }
 
@@ -414,11 +401,9 @@
         (remainder !== 0 ?
           (variant & 2) === 0 ? 4 : 2 + (remainder >>> 1) :
           0),
-        result = new AllocatedBuf(b64_len + 1),
+        result = _malloc_pool_buf(address_pool, b64_len + 1),
         result_b64,
-        input_address = _to_allocated_buf_address(input);
-      address_pool.push(input_address);
-      address_pool.push(result.address);
+        input_address = _to_allocated_buf_address(address_pool, input);
       if (
         libsodium._sodium_bin2base64(
           result.address,
@@ -430,9 +415,8 @@
       ) {
         _free_and_throw_error(address_pool, "conversion failed");
       }
-      result.length = b64_len;
-      result_b64 = to_string(result.to_Uint8Array());
-      _free_all(address_pool);
+      result_b64 = to_string(result.to_Uint8Array(b64_len));
+      _free_pool(address_pool);
       return result_b64;
     }
 
@@ -512,19 +496,23 @@
     }
 
     // Copy the content of a AllocatedBuf (_malloc()'d memory) into a Uint8Array
-    AllocatedBuf.prototype.to_Uint8Array = function () {
-      var result = new Uint8Array(this.length);
-      result.set(
-        libsodium.HEAPU8.subarray(this.address, this.address + this.length)
-      );
+    AllocatedBuf.prototype.to_Uint8Array = function (length) {
+      var n = length === undefined ? this.length : length;
+      var result = new Uint8Array(n);
+      result.set(libsodium.HEAPU8.subarray(this.address, this.address + n));
       return result;
     };
 
-    // _malloc() a region and initialize it with the content of a Uint8Array
-    function _to_allocated_buf_address(bytes) {
-      var address = _malloc(bytes.length);
-      libsodium.HEAPU8.set(bytes, address);
-      return address;
+    function _malloc_pool_buf(pool, size) {
+      var buf = new AllocatedBuf(size);
+      pool.push(buf);
+      return buf;
+    }
+
+    function _to_allocated_buf_address(pool, bytes) {
+      var buf = _malloc_pool_buf(pool, bytes.length);
+      libsodium.HEAPU8.set(bytes, buf.address);
+      return buf.address;
     }
 
     function _malloc(length) {
@@ -538,34 +526,40 @@
       return result;
     }
 
-    var _state_addresses = new Set();
+    var _state_addresses = new Map();
 
     function _malloc_state_address(size) {
-      var address = _malloc(size);
-      _state_addresses.add(address);
-      return address;
+      var buf = new AllocatedBuf(size);
+      _state_addresses.set(buf.address, buf);
+      return buf.address;
     }
 
     function _free_state_address(address) {
-      _state_addresses.delete(address);
+      var buf = _state_addresses.get(address);
+      if (buf !== undefined) {
+        libsodium.HEAPU8.fill(0, buf.address, buf.address + buf.length);
+        _state_addresses.delete(address);
+      }
       libsodium._free(address);
     }
 
-    function _free_all(addresses) {
-      if (addresses) {
-        for (var i = 0; i < addresses.length; i++) {
-          libsodium._free(addresses[i]);
+    function _free_pool(pool) {
+      if (pool) {
+        for (var i = 0; i < pool.length; i++) {
+          var buf = pool[i];
+          libsodium.HEAPU8.fill(0, buf.address, buf.address + buf.length);
+          libsodium._free(buf.address);
         }
       }
     }
 
     function _free_and_throw_error(address_pool, err) {
-      _free_all(address_pool);
+      _free_pool(address_pool);
       throw new Error(err);
     }
 
     function _free_and_throw_type_error(address_pool, err) {
-      _free_all(address_pool);
+      _free_pool(address_pool);
       throw new TypeError(err);
     }
 


### PR DESCRIPTION
The C library strives to overwrite memory containing potentially sensitive data before releasing it. This PR does the same for JS allocations that were left dirty in the WASM heap and could be exposed by bugs. Minor perf hit seems  worth the added safety. Unfortunately, this doesn't cleanup JS memory from activities like string encode/decode etc.

Also...
* simplified macro call sites that universally pushed to the memory pool by moving push into the allocators.
* added tests to assert output buffers, sodium.pad, and state_addresses are all zeroed.
* renamed _free_all since it's only meant to free the address_pool
* instead of mutating AllocatedBuf.length after allocation, changed to_Uint8Array to accept a length arg