### PR TITLE
implement JS wrapper definitions for crypto_kdf_hkdf

### DIFF
--- a/wrapper/macros/input_kdf_hkdf_sha256_state_address.js
+++ b/wrapper/macros/input_kdf_hkdf_sha256_state_address.js
@@ -1,0 +1,3 @@
+// ---------- input: {var_name} (kdf_hkdf_sha256_state_address)
+
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/input_kdf_hkdf_sha512_state_address.js
+++ b/wrapper/macros/input_kdf_hkdf_sha512_state_address.js
@@ -1,0 +1,3 @@
+// ---------- input: {var_name} (kdf_hkdf_sha512_state_address)
+
+_require_state_address(address_pool, {var_name});

--- a/wrapper/macros/output_kdf_hkdf_sha256_state.js
+++ b/wrapper/macros/output_kdf_hkdf_sha256_state.js
@@ -1,0 +1,3 @@
+// ---------- output {var_name} (kdf_hkdf_sha256_state)
+
+var {var_name}_address = _malloc_state_address(libsodium._crypto_kdf_hkdf_sha256_statebytes());

--- a/wrapper/macros/output_kdf_hkdf_sha512_state.js
+++ b/wrapper/macros/output_kdf_hkdf_sha512_state.js
@@ -1,0 +1,3 @@
+// ---------- output {var_name} (kdf_hkdf_sha512_state)
+
+var {var_name}_address = _malloc_state_address(libsodium._crypto_kdf_hkdf_sha512_statebytes());

--- a/wrapper/shared-types.ts
+++ b/wrapper/shared-types.ts
@@ -47,6 +47,8 @@ export const INPUT_TYPES = {
 
 export const STATE_TYPES = [
 	"generichash_state",
+	"kdf_hkdf_sha256_state",
+	"kdf_hkdf_sha512_state",
 	"hash_sha256_state",
 	"hash_sha512_state",
 	"hash_sha3256_state",

--- a/wrapper/symbols/crypto_kdf_hkdf_sha256_expand.json
+++ b/wrapper/symbols/crypto_kdf_hkdf_sha256_expand.json
@@ -1,0 +1,36 @@
+{
+  "name": "crypto_kdf_hkdf_sha256_expand",
+  "type": "function",
+  "inputs": [
+    {
+      "name": "out_len",
+      "type": "ranged_uint",
+      "min_value": "libsodium._crypto_kdf_hkdf_sha256_bytes_min()",
+      "max_value": "libsodium._crypto_kdf_hkdf_sha256_bytes_max()"
+    },
+    {
+      "name": "ctx",
+      "type": "unsized_string"
+    },
+    {
+      "name": "prk",
+      "type": "buf",
+      "length": "libsodium._crypto_kdf_hkdf_sha256_keybytes()"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "out",
+      "length": "out_len",
+      "type": "buf"
+    }
+  ],
+  "target": "libsodium._crypto_kdf_hkdf_sha256_expand(out_address, out_len, ctx_address, ctx_length, prk_address) | 0",
+  "assert_retval": [
+    {
+      "condition": "=== 0",
+      "or_else_throw": "invalid usage"
+    }
+  ],
+  "return": "_format_output(out, outputFormat)"
+}

--- a/wrapper/symbols/crypto_kdf_hkdf_sha256_extract.json
+++ b/wrapper/symbols/crypto_kdf_hkdf_sha256_extract.json
@@ -1,0 +1,29 @@
+{
+  "name": "crypto_kdf_hkdf_sha256_extract",
+  "type": "function",
+  "inputs": [
+    {
+      "name": "salt",
+      "type": "unsized_buf_optional"
+    },
+    {
+      "name": "ikm",
+      "type": "unsized_buf"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "prk",
+      "length": "libsodium._crypto_kdf_hkdf_sha256_keybytes()",
+      "type": "buf"
+    }
+  ],
+  "target": "libsodium._crypto_kdf_hkdf_sha256_extract(prk_address, salt_address, salt_length, ikm_address, ikm_length) | 0",
+  "assert_retval": [
+    {
+      "condition": "=== 0",
+      "or_else_throw": "invalid usage"
+    }
+  ],
+  "return": "_format_output(prk, outputFormat)"
+}

--- a/wrapper/symbols/crypto_kdf_hkdf_sha256_extract_final.json
+++ b/wrapper/symbols/crypto_kdf_hkdf_sha256_extract_final.json
@@ -1,0 +1,25 @@
+{
+  "name": "crypto_kdf_hkdf_sha256_extract_final",
+  "type": "function",
+  "inputs": [
+    {
+      "name": "state_address",
+      "type": "kdf_hkdf_sha256_state_address"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "prk",
+      "length": "libsodium._crypto_kdf_hkdf_sha256_keybytes()",
+      "type": "buf"
+    }
+  ],
+  "target": "libsodium._crypto_kdf_hkdf_sha256_extract_final(state_address, prk_address) | 0",
+  "assert_retval": [
+    {
+      "condition": "=== 0",
+      "or_else_throw": "invalid usage"
+    }
+  ],
+  "return": "(_free_state_address(state_address), _format_output(prk, outputFormat))"
+}

--- a/wrapper/symbols/crypto_kdf_hkdf_sha256_extract_init.json
+++ b/wrapper/symbols/crypto_kdf_hkdf_sha256_extract_init.json
@@ -1,0 +1,24 @@
+{
+  "name": "crypto_kdf_hkdf_sha256_extract_init",
+  "type": "function",
+  "inputs": [
+    {
+      "name": "salt",
+      "type": "unsized_buf_optional"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "state",
+      "type": "kdf_hkdf_sha256_state"
+    }
+  ],
+  "target": "libsodium._crypto_kdf_hkdf_sha256_extract_init(state_address, salt_address, salt_length) | 0",
+  "assert_retval": [
+    {
+      "condition": "=== 0",
+      "or_else_throw": "invalid usage"
+    }
+  ],
+  "return": "state_address"
+}

--- a/wrapper/symbols/crypto_kdf_hkdf_sha256_extract_update.json
+++ b/wrapper/symbols/crypto_kdf_hkdf_sha256_extract_update.json
@@ -1,0 +1,22 @@
+{
+  "name": "crypto_kdf_hkdf_sha256_extract_update",
+  "type": "function",
+  "inputs": [
+    {
+      "name": "state_address",
+      "type": "kdf_hkdf_sha256_state_address"
+    },
+    {
+      "name": "ikm",
+      "type": "unsized_buf"
+    }
+  ],
+  "target": "libsodium._crypto_kdf_hkdf_sha256_extract_update(state_address, ikm_address, ikm_length) | 0",
+  "assert_retval": [
+    {
+      "condition": "=== 0",
+      "or_else_throw": "invalid usage"
+    }
+  ],
+  "outputs": []
+}

--- a/wrapper/symbols/crypto_kdf_hkdf_sha256_keygen.json
+++ b/wrapper/symbols/crypto_kdf_hkdf_sha256_keygen.json
@@ -1,0 +1,14 @@
+{
+  "name": "crypto_kdf_hkdf_sha256_keygen",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "name": "prk",
+      "length": "libsodium._crypto_kdf_hkdf_sha256_keybytes()",
+      "type": "buf"
+    }
+  ],
+  "target": "libsodium._crypto_kdf_hkdf_sha256_keygen(prk_address)",
+  "return": "_format_output(prk, outputFormat)"
+}

--- a/wrapper/symbols/crypto_kdf_hkdf_sha512_expand.json
+++ b/wrapper/symbols/crypto_kdf_hkdf_sha512_expand.json
@@ -1,0 +1,36 @@
+{
+  "name": "crypto_kdf_hkdf_sha512_expand",
+  "type": "function",
+  "inputs": [
+    {
+      "name": "out_len",
+      "type": "ranged_uint",
+      "min_value": "libsodium._crypto_kdf_hkdf_sha512_bytes_min()",
+      "max_value": "libsodium._crypto_kdf_hkdf_sha512_bytes_max()"
+    },
+    {
+      "name": "ctx",
+      "type": "unsized_string"
+    },
+    {
+      "name": "prk",
+      "type": "buf",
+      "length": "libsodium._crypto_kdf_hkdf_sha512_keybytes()"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "out",
+      "length": "out_len",
+      "type": "buf"
+    }
+  ],
+  "target": "libsodium._crypto_kdf_hkdf_sha512_expand(out_address, out_len, ctx_address, ctx_length, prk_address) | 0",
+  "assert_retval": [
+    {
+      "condition": "=== 0",
+      "or_else_throw": "invalid usage"
+    }
+  ],
+  "return": "_format_output(out, outputFormat)"
+}

--- a/wrapper/symbols/crypto_kdf_hkdf_sha512_extract.json
+++ b/wrapper/symbols/crypto_kdf_hkdf_sha512_extract.json
@@ -1,0 +1,29 @@
+{
+  "name": "crypto_kdf_hkdf_sha512_extract",
+  "type": "function",
+  "inputs": [
+    {
+      "name": "salt",
+      "type": "unsized_buf_optional"
+    },
+    {
+      "name": "ikm",
+      "type": "unsized_buf"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "prk",
+      "length": "libsodium._crypto_kdf_hkdf_sha512_keybytes()",
+      "type": "buf"
+    }
+  ],
+  "target": "libsodium._crypto_kdf_hkdf_sha512_extract(prk_address, salt_address, salt_length, ikm_address, ikm_length) | 0",
+  "assert_retval": [
+    {
+      "condition": "=== 0",
+      "or_else_throw": "invalid usage"
+    }
+  ],
+  "return": "_format_output(prk, outputFormat)"
+}

--- a/wrapper/symbols/crypto_kdf_hkdf_sha512_extract_final.json
+++ b/wrapper/symbols/crypto_kdf_hkdf_sha512_extract_final.json
@@ -1,0 +1,25 @@
+{
+  "name": "crypto_kdf_hkdf_sha512_extract_final",
+  "type": "function",
+  "inputs": [
+    {
+      "name": "state_address",
+      "type": "kdf_hkdf_sha512_state_address"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "prk",
+      "length": "libsodium._crypto_kdf_hkdf_sha512_keybytes()",
+      "type": "buf"
+    }
+  ],
+  "target": "libsodium._crypto_kdf_hkdf_sha512_extract_final(state_address, prk_address) | 0",
+  "assert_retval": [
+    {
+      "condition": "=== 0",
+      "or_else_throw": "invalid usage"
+    }
+  ],
+  "return": "(_free_state_address(state_address), _format_output(prk, outputFormat))"
+}

--- a/wrapper/symbols/crypto_kdf_hkdf_sha512_extract_init.json
+++ b/wrapper/symbols/crypto_kdf_hkdf_sha512_extract_init.json
@@ -1,0 +1,24 @@
+{
+  "name": "crypto_kdf_hkdf_sha512_extract_init",
+  "type": "function",
+  "inputs": [
+    {
+      "name": "salt",
+      "type": "unsized_buf_optional"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "state",
+      "type": "kdf_hkdf_sha512_state"
+    }
+  ],
+  "target": "libsodium._crypto_kdf_hkdf_sha512_extract_init(state_address, salt_address, salt_length) | 0",
+  "assert_retval": [
+    {
+      "condition": "=== 0",
+      "or_else_throw": "invalid usage"
+    }
+  ],
+  "return": "state_address"
+}

--- a/wrapper/symbols/crypto_kdf_hkdf_sha512_extract_update.json
+++ b/wrapper/symbols/crypto_kdf_hkdf_sha512_extract_update.json
@@ -1,0 +1,22 @@
+{
+  "name": "crypto_kdf_hkdf_sha512_extract_update",
+  "type": "function",
+  "inputs": [
+    {
+      "name": "state_address",
+      "type": "kdf_hkdf_sha512_state_address"
+    },
+    {
+      "name": "ikm",
+      "type": "unsized_buf"
+    }
+  ],
+  "target": "libsodium._crypto_kdf_hkdf_sha512_extract_update(state_address, ikm_address, ikm_length) | 0",
+  "assert_retval": [
+    {
+      "condition": "=== 0",
+      "or_else_throw": "invalid usage"
+    }
+  ],
+  "outputs": []
+}

--- a/wrapper/symbols/crypto_kdf_hkdf_sha512_keygen.json
+++ b/wrapper/symbols/crypto_kdf_hkdf_sha512_keygen.json
@@ -1,0 +1,14 @@
+{
+  "name": "crypto_kdf_hkdf_sha512_keygen",
+  "type": "function",
+  "inputs": [],
+  "outputs": [
+    {
+      "name": "prk",
+      "length": "libsodium._crypto_kdf_hkdf_sha512_keybytes()",
+      "type": "buf"
+    }
+  ],
+  "target": "libsodium._crypto_kdf_hkdf_sha512_keygen(prk_address)",
+  "return": "_format_output(prk, outputFormat)"
+}


### PR DESCRIPTION
This PR adds the currently missing family of `crypto_kdf_hkdf_*` to the wrappers (See #335).

For now, I only added the wrapper definitions. @jedisct1 Do you prefer If I generate the updated distributable files etc. as well? I built them locally, but get about ~190 modified files, so I am unsure if I am using the correct toolchain versions. I can commit those files, but I wanted your approval for that first, as you might want to build them yourself.